### PR TITLE
Reduce default operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Configurations in `MonkeyConfig`:
 - **IsInteractable**: Function returns whether the `Component` is interactable or not. The default implementation returns true if the component is a uGUI compatible component and its `interactable` property is true.
 - **IgnoreStrategy**: Strategy to examine whether `GameObject` should be ignored. The default implementation returns true if the `GameObject` has `IgnoreAnnotation` attached.
 - **ReachableStrategy**: Strategy to examine whether `GameObject` is reachable from the user. The default implementation returns true if it can raycast from `Camera.main` to the pivot position.
-- **Operators**: A collection of `IOperator` that the monkey invokes. The default is `UguiClickOperator`, `UguiClickAndHoldOperator`, `UguiDoubleClickOperator`, `UguiScrollWheelOperator`, and `UguiTextInputOperator`. There is support for standard uGUI components.
+- **Operators**: A collection of `IOperator` that the monkey invokes. The default is `UguiClickOperator` and `UguiTextInputOperator`. There is support for standard uGUI components.
 
 Class diagram for default strategies:
 
@@ -337,9 +337,6 @@ classDiagram
 
     IOperator <|-- IClickOperator
     IClickOperator <|-- UguiClickOperator
-
-    IOperator <|-- IClickAndHoldOperator
-    IClickAndHoldOperator <|-- UguiClickAndHoldOperator
 
     IOperator <|-- ITextInputOperator
     ITextInputOperator <|-- UguiTextInputOperator

--- a/Runtime/MonkeyConfig.cs
+++ b/Runtime/MonkeyConfig.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using TestHelper.Random;
 using TestHelper.UI.Exceptions;
 using TestHelper.UI.Operators;
 using TestHelper.UI.Strategies;
-using TestHelper.Random;
 using UnityEngine;
 
 namespace TestHelper.UI
@@ -94,10 +94,7 @@ namespace TestHelper.UI
         public IEnumerable<IOperator> Operators { get; set; } = new IOperator[]
         {
             new UguiClickOperator(),
-            new UguiClickAndHoldOperator(),
-            new UguiDoubleClickOperator(),
-            new UguiScrollWheelOperator(), // Specify PRNG instance, if necessary
-            new UguiTextInputOperator(),   // Specify random text input strategy, if necessary
+            new UguiTextInputOperator(), // Specify random text input strategy, if necessary
         };
     }
 }


### PR DESCRIPTION
### Changes

Remove the following operators from the `MonkeyConfig` defaults:

- UguiClickAndHoldOperator
- UguiDoubleClickOperator
- UguiScrollWheelOperator
