### PR TITLE
Set PRNG instance to randomizable operators when starting up monkey tests

### DIFF
--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -8,11 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using TestHelper.UI.Exceptions;
-using TestHelper.UI.Operators;
-using TestHelper.UI.Strategies;
 using TestHelper.Random;
 using TestHelper.RuntimeInternals;
+using TestHelper.UI.Exceptions;
+using TestHelper.UI.Operators;
+using TestHelper.UI.Random;
+using TestHelper.UI.Strategies;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -52,11 +53,7 @@ namespace TestHelper.UI
                 GameViewControlHelper.SetGizmos(true);
             }
 
-            foreach (var iOperator in config.Operators)
-            {
-                iOperator.Logger = config.Logger;
-                iOperator.ScreenshotOptions = config.Screenshots;
-            }
+            SetupOperators(config);
 
             var interactableComponentsFinder =
                 new InteractableComponentsFinder(config.IsInteractable, config.Operators);
@@ -113,6 +110,20 @@ namespace TestHelper.UI
                 if (config.Gizmos)
                 {
                     GameViewControlHelper.SetGizmos(beforeGizmos);
+                }
+            }
+        }
+
+        private static void SetupOperators(MonkeyConfig config)
+        {
+            foreach (var iOperator in config.Operators)
+            {
+                iOperator.Logger = config.Logger;
+                iOperator.ScreenshotOptions = config.Screenshots;
+
+                if (iOperator is IRandomizable randomizable)
+                {
+                    randomizable.Random = config.Random.Fork();
                 }
             }
         }

--- a/Runtime/MonkeyConfig.cs
+++ b/Runtime/MonkeyConfig.cs
@@ -94,7 +94,7 @@ namespace TestHelper.UI
         public IEnumerable<IOperator> Operators { get; set; } = new IOperator[]
         {
             new UguiClickOperator(),
-            new UguiTextInputOperator(), // Specify random text input strategy, if necessary
+            new UguiTextInputOperator(),
         };
     }
 }

--- a/Runtime/Operators/UguiDragAndDropOperator.cs
+++ b/Runtime/Operators/UguiDragAndDropOperator.cs
@@ -43,7 +43,11 @@ namespace TestHelper.UI.Operators
         {
             private get
             {
-                _random ??= new RandomWrapper();
+                if (_random == null)
+                {
+                    _random = new RandomWrapper();
+                }
+
                 return _random;
             }
             set

--- a/Runtime/Operators/UguiScrollWheelOperator.cs
+++ b/Runtime/Operators/UguiScrollWheelOperator.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using TestHelper.Random;
 using TestHelper.UI.Extensions;
 using TestHelper.UI.Operators.Utils;
-using TestHelper.Random;
+using TestHelper.UI.Random;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -15,7 +16,10 @@ namespace TestHelper.UI.Operators
     /// <summary>
     /// Scroll wheel operator for Unity UI (uGUI) components that implements IScrollHandler.
     /// </summary>
-    public class UguiScrollWheelOperator : IScrollWheelOperator
+    /// <remarks>
+    /// If no scroll destination is specified (e.g., in monkey testing), a random scroll destinations will be used.
+    /// </remarks>
+    public class UguiScrollWheelOperator : IScrollWheelOperator, IRandomizable
     {
         /// <inheritdoc/>
         public ILogger Logger { private get; set; }
@@ -23,7 +27,21 @@ namespace TestHelper.UI.Operators
         /// <inheritdoc/>
         public ScreenshotOptions ScreenshotOptions { private get; set; }
 
-        private readonly IRandom _random;
+        /// <inheritdoc/>
+        public IRandom Random
+        {
+            private get
+            {
+                _random ??= new RandomWrapper();
+                return _random;
+            }
+            set
+            {
+                _random = value;
+            }
+        }
+
+        private IRandom _random;
         private readonly float _scrollSpeed;
 
         /// <summary>
@@ -43,7 +61,7 @@ namespace TestHelper.UI.Operators
             }
 
             _scrollSpeed = scrollSpeed;
-            _random = random ?? new RandomWrapper();
+            _random = random;
             Logger = logger ?? Debug.unityLogger;
             ScreenshotOptions = screenshotOptions;
         }
@@ -65,8 +83,8 @@ namespace TestHelper.UI.Operators
         {
             var distance = CalcMaxScrollDistance(gameObject);
             var destination = new Vector2(
-                _random.Next(-distance, distance),
-                _random.Next(-distance, distance)
+                Random.Next(-distance, distance),
+                Random.Next(-distance, distance)
             );
             await OperateAsync(gameObject, destination, raycastResult, cancellationToken);
         }

--- a/Runtime/Operators/UguiScrollWheelOperator.cs
+++ b/Runtime/Operators/UguiScrollWheelOperator.cs
@@ -32,7 +32,11 @@ namespace TestHelper.UI.Operators
         {
             private get
             {
-                _random ??= new RandomWrapper();
+                if (_random == null)
+                {
+                    _random = new RandomWrapper();
+                }
+
                 return _random;
             }
             set

--- a/Runtime/Operators/UguiTextInputOperator.cs
+++ b/Runtime/Operators/UguiTextInputOperator.cs
@@ -5,11 +5,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using TestHelper.Random;
 using TestHelper.UI.Annotations;
 using TestHelper.UI.Extensions;
 using TestHelper.UI.Operators.Utils;
 using TestHelper.UI.Random;
-using TestHelper.Random;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -17,20 +17,30 @@ using UnityEngine.UI;
 using TMPro;
 #endif
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
 namespace TestHelper.UI.Operators
 {
     /// <summary>
     /// Text input operator for Unity UI (uGUI) <c>InputField</c> component.
     /// </summary>
-    public class UguiTextInputOperator : ITextInputOperator
+    /// <remarks>
+    /// If no text is specified (e.g., in the case of monkey tests), a random string will be entered.
+    /// </remarks>
+    public class UguiTextInputOperator : ITextInputOperator, IRandomizable
     {
         /// <inheritdoc/>
         public ILogger Logger { private get; set; }
 
         /// <inheritdoc/>
         public ScreenshotOptions ScreenshotOptions { private get; set; }
+
+        /// <inheritdoc/>
+        public IRandom Random
+        {
+            set
+            {
+                _randomString.Random = value;
+            }
+        }
 
         private readonly Func<GameObject, RandomStringParameters> _randomStringParams;
         private readonly IRandomString _randomString;

--- a/Runtime/Operators/UguiToggleOperator.cs
+++ b/Runtime/Operators/UguiToggleOperator.cs
@@ -13,8 +13,11 @@ namespace TestHelper.UI.Operators
     /// <summary>
     /// Toggle operator for <see cref="Toggle"/> component.
     /// You can click to turn it on/off, or you can specify the on/off state.
-    /// In monkey testing, it behaves the same as the <see cref="UguiClickOperator"/>.
     /// </summary>
+    /// <remarks>
+    /// If state is not specified (e.g., in monkey testing), it will always be flipped (same as click).
+    /// </remarks>
+    /// <seealso cref="UguiClickOperator"/>
     public class UguiToggleOperator : UguiClickOperator, IToggleOperator
     {
         /// <summary>

--- a/Runtime/Random/IRandomString.cs
+++ b/Runtime/Random/IRandomString.cs
@@ -3,7 +3,7 @@
 
 namespace TestHelper.UI.Random
 {
-    public interface IRandomString
+    public interface IRandomString : IRandomizable
     {
         string Next(RandomStringParameters parameters);
     }

--- a/Runtime/Random/IRandomizable.cs
+++ b/Runtime/Random/IRandomizable.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2023-2025 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using TestHelper.Random;
+
+namespace TestHelper.UI.Random
+{
+    /// <summary>
+    /// Operators that behave randomly in monkey testing.
+    /// </summary>
+    public interface IRandomizable
+    {
+        /// <summary>
+        /// Pseudo-random number generator instance.
+        /// </summary>
+        IRandom Random { set; }
+    }
+}

--- a/Runtime/Random/IRandomizable.cs.meta
+++ b/Runtime/Random/IRandomizable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9cd6b75f8e84468f8ea2efeb26cd791d
+timeCreated: 1758303958

--- a/Runtime/Random/RandomStringImpl.cs
+++ b/Runtime/Random/RandomStringImpl.cs
@@ -26,7 +26,11 @@ namespace TestHelper.UI.Random
         {
             private get
             {
-                _random ??= new RandomWrapper();
+                if (_random == null)
+                {
+                    _random = new RandomWrapper();
+                }
+
                 return _random;
             }
             set

--- a/Runtime/Random/RandomStringImpl.cs
+++ b/Runtime/Random/RandomStringImpl.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Text;
-using TestHelper.UI.Annotations.Enums;
 using TestHelper.Random;
-using UnityEngine;
+using TestHelper.UI.Annotations.Enums;
 using UnityEngine.Assertions;
 
 namespace TestHelper.UI.Random
@@ -20,8 +19,21 @@ namespace TestHelper.UI.Random
         internal const string CharsASCIIPrintable = CharsASCIIAlphanumeric + CharsASCIISymbols;
 
         private static StringBuilder _sb = new StringBuilder();
-        private readonly IRandom _random;
+        private IRandom _random;
 
+        /// <inheritdoc/>
+        public IRandom Random
+        {
+            private get
+            {
+                _random ??= new RandomWrapper();
+                return _random;
+            }
+            set
+            {
+                _random = value;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <c>RandomStringImpl</c> class,
@@ -29,11 +41,10 @@ namespace TestHelper.UI.Random
         /// <remarks>This class is not thread-safe.</remarks>
         /// </summary>
         /// <param name="random">Random number generator</param>
-        public RandomStringImpl(IRandom random)
+        public RandomStringImpl(IRandom random = null)
         {
-            _random = random;
+            Random = random;
         }
-
 
         /// <summary>
         /// Returns a random string.
@@ -44,19 +55,18 @@ namespace TestHelper.UI.Random
         public string Next(RandomStringParameters parameters)
         {
             Assert.IsTrue(parameters.MinimumLength <= parameters.MaximumLength);
-            var len = parameters.MinimumLength + _random.Next(parameters.MaximumLength - parameters.MinimumLength + 1);
+            var len = parameters.MinimumLength + Random.Next(parameters.MaximumLength - parameters.MinimumLength + 1);
 
             var chars = GetCharsByKind(parameters.CharactersKind);
 
             _sb.Clear();
             for (var i = 0; i < len; i++)
             {
-                _sb.Append(chars[_random.Next(chars.Length)]);
+                _sb.Append(chars[Random.Next(chars.Length)]);
             }
 
             return _sb.ToString();
         }
-
 
         private static string GetCharsByKind(CharactersKind charactersKind)
         {

--- a/Tests/Runtime/TestDoubles/StubRandomString.cs
+++ b/Tests/Runtime/TestDoubles/StubRandomString.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using TestHelper.Random;
 using TestHelper.UI.Random;
 
 namespace TestHelper.UI.TestDoubles
@@ -12,6 +13,7 @@ namespace TestHelper.UI.TestDoubles
         private readonly string[] _returnValues;
         private int _returnValueIndex;
 
+        public IRandom Random { get; set; }
 
         public StubRandomString(params string[] returnValues)
         {
@@ -19,7 +21,6 @@ namespace TestHelper.UI.TestDoubles
             _returnValues = returnValues;
             _returnValueIndex = 0;
         }
-
 
         public string Next(RandomStringParameters _)
         {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
     "com.nowsprinting.test-helper": "1.1.1",
-    "com.nowsprinting.test-helper.random": "1.0.0",
+    "com.nowsprinting.test-helper.random": "1.1.0",
     "com.unity.ugui": "1.0.0"
   },
   "displayName": "UI Test Helper",


### PR DESCRIPTION
### Problem

The behavior of the operators used in monkey tests cannot be made deterministic.

- `UguiDragAndDropOperator`
- `UguiScrollWheelOperator`
- `UguiTextInputOperator`

### Cause

This is because the PRNG configured in `MonkeyConfig` is not used.

### Fixes

- Upgrade test-helper.random package from v1.0.0 to v1.1.0
- Add `IRandomizable` interface to allow PRNG injection into operators
- Modify follows operators to implement `IRandomizable` and use injected PRNG instances
- Update monkey test startup to configure PRNG for randomizable operators