### PR TITLE
Upgrade Unity versions used to run tests on CI, and remove 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,14 @@ jobs:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.40f1
           - 2022.3.62f1
-          - 6000.0.56f1
-          - 6000.1.16f1
-          - 6000.2.0f1
+          - 6000.0.58f1
+          - 6000.2.4f1
         testMode:
           - All # run tests in editor
         include:
-          - unityVersion: 6000.2.0f1
+          - unityVersion: 6000.2.4f1
             octocov: true
-          - unityVersion: 6000.2.0f1
+          - unityVersion: 6000.2.4f1
             testMode: Standalone  # run tests on player
 
     steps:


### PR DESCRIPTION
### Changes

#### Upgrade

- 6000.0.58f1
- 6000.2.4f1

#### Remove

- 6000.1