### PR TITLE
Rework performance tests to compare runtime optimization branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,10 @@ jobs:
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
         if: ${{ matrix.inputHandler != '0' }}
 
-      - name: Install codecoverage package
+      - name: Install code-coverage and performance-testing package
         run: |
           openupm add -f com.unity.testtools.codecoverage
+          openupm add -f com.unity.test-framework.performance
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
         if: ${{ matrix.octocov }}
 
@@ -133,7 +134,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test (${{ matrix.unityVersion }}, ${{ matrix.testMode }}, ${{ matrix.inputHandler }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -retry 5 -testCategory "!IgnoreCI" -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots
+          customParameters: -retry 5 -testCategory "!IgnoreCI" -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots -perfTestResults /github/workspace/artifacts/PerformanceTestResults.json
           # Note: `/github/workspace/artifacts` is the artifacts path inside the game-ci container
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html

--- a/Tests/Performance/GameObjectFinderTest.cs
+++ b/Tests/Performance/GameObjectFinderTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using TestHelper.Attributes;
+using TestHelper.UI.GameObjectMatchers;
+using TestHelper.UI.Paginators;
+using Unity.PerformanceTesting;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TestHelper.UI.Performance
+{
+    [TestFixture]
+    public class GameObjectFinderTest
+    {
+        private const int ButtonCount = 1000;
+        private const int NestDepth = 10;
+        private static readonly string s_targetButtonName = $"Button_{ButtonCount - 1}";
+
+        [Test]
+        [Performance]
+        [CreateScene(camera: true)]
+        public async Task FindByMatcherAsync_ButtonMatcherAmongManyGameObjects_MeasureTimeAndAllocations()
+        {
+            UiFixtureFactory.CreateNestedButtons(ButtonCount, NestDepth);
+
+            var finder = new GameObjectFinder();
+            var matcher = new ButtonMatcher(text: s_targetButtonName);
+
+            // reachable: false because the generated buttons have no Image, so raycasts can never hit them;
+            // the subject here is the hierarchy scan and matcher, not reachability.
+            await PerformanceMeasurement.MeasureAsync(() => finder.FindByMatcherAsync(matcher, reachable: false));
+        }
+
+        [Test]
+        [Performance]
+        [CreateScene(camera: true)]
+        public async Task FindByNameAsync_AmongManyGameObjects_MeasureTimeAndAllocations()
+        {
+            UiFixtureFactory.CreateNestedButtons(ButtonCount, NestDepth);
+
+            var finder = new GameObjectFinder();
+
+            await PerformanceMeasurement.MeasureAsync(() =>
+                finder.FindByNameAsync(s_targetButtonName, reachable: false));
+        }
+
+        [Test]
+        [Performance]
+        [LoadScene("../Scenes/ScrollViews.unity")]
+        public async Task FindByMatcherAsync_WithPaginatorInScrollView_MeasureTimeAndAllocations()
+        {
+            var scrollView = GameObject.Find("Vertical Scroll View");
+            Assume.That(scrollView, Is.Not.Null);
+
+            var finder = new GameObjectFinder(timeoutSeconds: 5.0d);
+            // The last button in the scroll view, so every iteration sweeps all pages.
+            var matcher = new ButtonMatcher(name: "Vertical_Button_29");
+            var paginator = new UguiScrollRectPaginator(scrollView.GetComponent<ScrollRect>());
+
+            await PerformanceMeasurement.MeasureAsync(() =>
+                finder.FindByMatcherAsync(matcher, reachable: true, paginator: paginator));
+        }
+    }
+}

--- a/Tests/Performance/GameObjectFinderTest.cs.meta
+++ b/Tests/Performance/GameObjectFinderTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04783e89714474f44bc8e5e6d016b710

--- a/Tests/Performance/MonkeyTest.cs
+++ b/Tests/Performance/MonkeyTest.cs
@@ -1,75 +1,47 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System.Collections;
+using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.Random;
+using TestHelper.UI.Operators;
 using Unity.PerformanceTesting;
-using UnityEngine.TestTools;
+using UnityEngine;
 
 namespace TestHelper.UI.Performance
 {
+    [TestFixture]
     public class MonkeyTest
     {
-        private const string MeasurePackageVersion = "0.13.3";
+        private const int GridButtonCount = 10;
 
         [Test]
-        [Performance, Version(MeasurePackageVersion)]
-        [LoadScene("../Scenes/Operators.unity")]
-        public void GetLotteryEntries_GotAllInteractableComponentAndOperators()
+        [Performance]
+        [CreateScene(camera: true)]
+        public async Task RunStep_SeededRandom_MeasureTimeAndAllocations()
         {
-            var config = new MonkeyConfig();
-            var finder = new InteractableComponentsFinder(config.IsInteractable, config.OperatorPool);
+            UiFixtureFactory.CreateGridButtons(GridButtonCount);
+            // Without a rendered frame, CanvasRenderer.depth stays -1 and GraphicRaycaster skips the buttons.
+            Canvas.ForceUpdateCanvases();
+            await UniTask.NextFrame();
 
-            Measure.Method(() =>
-                {
-                    // ReSharper disable once IteratorMethodResultIsIgnored
-                    Monkey.GetLotteryEntries(finder);
-                })
-                .WarmupCount(5)
-                .MeasurementCount(20)
-                .GC()
-                .Run();
-        }
-
-        [Test]
-        [Performance, Version(MeasurePackageVersion)]
-        [LoadScene("../Scenes/PhysicsRaycasterSandbox.unity")]
-        public void LotteryOperator_BingoReachableComponent()
-        {
-            var config = new MonkeyConfig();
-            var finder = new InteractableComponentsFinder(config.IsInteractable, config.OperatorPool);
-            var operators = Monkey.GetLotteryEntries(finder);
-
-            Measure.Method(() =>
-                {
-                    Monkey.LotteryOperator(operators, config.Random, config.IgnoreStrategy, config.ReachableStrategy);
-                })
-                .WarmupCount(5)
-                .MeasurementCount(20)
-                .GC()
-                .Run();
-        }
-
-        [UnityTest]
-        [Performance, Version(MeasurePackageVersion)]
-        [LoadScene("../Scenes/Operators.unity")]
-        public IEnumerator RunStep_finish()
-        {
-            var config = new MonkeyConfig();
-            var finder = new InteractableComponentsFinder(config.IsInteractable, config.OperatorPool);
-
-            using (Measure.Frames().Scope())
+            var config = new MonkeyConfig
             {
-                yield return Monkey.RunStep(
-                        config.Random,
-                        config.Logger,
-                        finder,
-                        config.IgnoreStrategy,
-                        config.ReachableStrategy)
-                    .ToCoroutine();
-            }
+                Random = new RandomWrapper(0), // pin seed for branch comparison
+                // Only the click operator is registered; UguiClickAndHoldOperator's hold time would dominate the
+                // measurement, hiding the cost of the lottery and reachability paths this test is meant to sample.
+                OperatorPool = new OperatorPool().Register<UguiClickOperator>()
+            };
+            var finder = new InteractableComponentsFinder(config.IsInteractable, config.OperatorPool);
+
+            var (didAction, _) = await Monkey.RunStep(
+                config.Random, config.Logger, finder, config.IgnoreStrategy, config.ReachableStrategy);
+            Assume.That(didAction, Is.True); // the generated buttons are actually operable
+
+            await PerformanceMeasurement.MeasureAsync(() => Monkey.RunStep(
+                config.Random, config.Logger, finder, config.IgnoreStrategy, config.ReachableStrategy));
         }
     }
 }

--- a/Tests/Performance/PerformanceMeasurement.cs
+++ b/Tests/Performance/PerformanceMeasurement.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Cysharp.Threading.Tasks;
+using Unity.PerformanceTesting;
+
+namespace TestHelper.UI.Performance
+{
+    // Measure.Method().GC() only accepts synchronous delegates, so async APIs are sampled manually with
+    // Measure.Custom: Stopwatch for time and GC.GetAllocatedBytesForCurrentThread for allocations.
+    // GC.GetAllocatedBytesForCurrentThread requires .NET Standard 2.1; the assembly's defineConstraints
+    // (UNITY_2021_2_OR_NEWER) guarantee it, so no in-code version guard is needed.
+    internal static class PerformanceMeasurement
+    {
+        private const int WarmupCount = 5;
+        private const int MeasurementCount = 20;
+
+        public static async UniTask MeasureAsync(Func<UniTask> action)
+        {
+            var timeGroup = new SampleGroup("Time");
+            var allocationGroup = new SampleGroup("GC.Alloc", SampleUnit.Byte);
+            var stopwatch = new Stopwatch();
+
+            for (var i = 0; i < WarmupCount; i++)
+            {
+                await action();
+            }
+
+            for (var i = 0; i < MeasurementCount; i++)
+            {
+                var allocatedBytesBefore = GC.GetAllocatedBytesForCurrentThread();
+                stopwatch.Restart();
+                await action();
+                stopwatch.Stop();
+                // Read the counter before Measure.Custom so the sampling machinery's own allocations are not
+                // charged to the GC.Alloc sample.
+                var allocatedBytesAfter = GC.GetAllocatedBytesForCurrentThread();
+
+                Measure.Custom(timeGroup, stopwatch.Elapsed.TotalMilliseconds);
+                Measure.Custom(allocationGroup, allocatedBytesAfter - allocatedBytesBefore);
+            }
+        }
+    }
+}

--- a/Tests/Performance/PerformanceMeasurement.cs
+++ b/Tests/Performance/PerformanceMeasurement.cs
@@ -67,7 +67,11 @@ namespace TestHelper.UI.Performance
             var delta = GC.GetTotalMemory(false) - before;
             GC.KeepAlive(probe);
 
-            Assume.That(delta, Is.GreaterThanOrEqualTo(CounterProbeSize),
+            // Not GetTotalMemory(true): forcing a collection also reclaims unrelated garbage, which lands the
+            // delta just below the probe size (995,328 of 1,000,000 observed) and fails a working counter.
+            // Half the probe size is the threshold because this only has to separate a live counter from a
+            // dead one, and a dead one reports a flat 0.
+            Assume.That(delta, Is.GreaterThan(CounterProbeSize / 2),
                 "The allocation counter does not move on this runtime, so GC.Alloc samples would all read 0.");
         }
     }

--- a/Tests/Performance/PerformanceMeasurement.cs
+++ b/Tests/Performance/PerformanceMeasurement.cs
@@ -4,21 +4,35 @@
 using System;
 using System.Diagnostics;
 using Cysharp.Threading.Tasks;
+using NUnit.Framework;
 using Unity.PerformanceTesting;
 
 namespace TestHelper.UI.Performance
 {
     // Measure.Method().GC() only accepts synchronous delegates, so async APIs are sampled manually with
-    // Measure.Custom: Stopwatch for time and GC.GetAllocatedBytesForCurrentThread for allocations.
-    // GC.GetAllocatedBytesForCurrentThread requires .NET Standard 2.1; the assembly's defineConstraints
-    // (UNITY_2021_2_OR_NEWER) guarantee it, so no in-code version guard is needed.
+    // Measure.Custom: Stopwatch for time and the managed heap size for allocations.
+    //
+    // The GC.Alloc samples are managed heap growth, not an exact allocation count: the heap grows in pages,
+    // so allocations that fit in already-reserved space read as 0. Compare medians across branches rather
+    // than reading a sample as "this operation allocated N bytes".
+    //
+    // GC.GetAllocatedBytesForCurrentThread is not used: it is a stub on Unity's Mono runtime and always
+    // returns 0, so it reports "no allocations" for everything instead of failing.
+    // ProfilerRecorder(ProfilerCategory.Memory, "GC.Alloc") — what Measure.Method().GC() uses — is not used
+    // either: it yields data only while the Profiler is recording, and Profiler.enabled is false in a plain
+    // Editor test run (which is also how CI runs these), where it silently reports unrelated values.
     internal static class PerformanceMeasurement
     {
-        private const int WarmupCount = 5;
+        // The heap grows in pages, so the first iterations report the expansion rather than the steady-state
+        // cost. Warm up long enough for the managed heap to settle before sampling.
+        private const int WarmupCount = 30;
         private const int MeasurementCount = 20;
+        private const int CounterProbeSize = 1_000_000;
 
         public static async UniTask MeasureAsync(Func<UniTask> action)
         {
+            AssumeAllocationCounterIsAlive();
+
             var timeGroup = new SampleGroup("Time");
             var allocationGroup = new SampleGroup("GC.Alloc", SampleUnit.Byte);
             var stopwatch = new Stopwatch();
@@ -30,17 +44,31 @@ namespace TestHelper.UI.Performance
 
             for (var i = 0; i < MeasurementCount; i++)
             {
-                var allocatedBytesBefore = GC.GetAllocatedBytesForCurrentThread();
+                // Not forcing a collection per sample: it frees enough space that the following allocations fit
+                // without growing the heap, which reads as a flat 0 bytes and destroys the signal entirely.
+                var heapBefore = GC.GetTotalMemory(false);
                 stopwatch.Restart();
                 await action();
                 stopwatch.Stop();
-                // Read the counter before Measure.Custom so the sampling machinery's own allocations are not
-                // charged to the GC.Alloc sample.
-                var allocatedBytesAfter = GC.GetAllocatedBytesForCurrentThread();
+                // Read the heap size before Measure.Custom so the sampling machinery's own allocations are not
+                // charged to the GC.Alloc sample. A sample turns negative when a collection happens to run
+                // inside the window; the median is the statistic to compare.
+                var heapAfter = GC.GetTotalMemory(false);
 
                 Measure.Custom(timeGroup, stopwatch.Elapsed.TotalMilliseconds);
-                Measure.Custom(allocationGroup, allocatedBytesAfter - allocatedBytesBefore);
+                Measure.Custom(allocationGroup, heapAfter - heapBefore);
             }
+        }
+
+        private static void AssumeAllocationCounterIsAlive()
+        {
+            var before = GC.GetTotalMemory(false);
+            var probe = new byte[CounterProbeSize];
+            var delta = GC.GetTotalMemory(false) - before;
+            GC.KeepAlive(probe);
+
+            Assume.That(delta, Is.GreaterThanOrEqualTo(CounterProbeSize),
+                "The allocation counter does not move on this runtime, so GC.Alloc samples would all read 0.");
         }
     }
 }

--- a/Tests/Performance/PerformanceMeasurement.cs.meta
+++ b/Tests/Performance/PerformanceMeasurement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fdb8929b45d7541ed9d4e3a0822de149

--- a/Tests/Performance/TestHelper.UI.Performance.Tests.asmdef
+++ b/Tests/Performance/TestHelper.UI.Performance.Tests.asmdef
@@ -20,7 +20,7 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS",
-        "UNITY_2020_3_OR_NEWER",
+        "UNITY_2021_2_OR_NEWER",
         "ENABLE_PERFORMANCE_TESTING"
     ],
     "versionDefines": [

--- a/Tests/Performance/TestHelper.UI.Performance.Tests.asmdef
+++ b/Tests/Performance/TestHelper.UI.Performance.Tests.asmdef
@@ -20,7 +20,7 @@
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS",
-        "UNITY_2021_2_OR_NEWER",
+        "UNITY_2020_3_OR_NEWER",
         "ENABLE_PERFORMANCE_TESTING"
     ],
     "versionDefines": [

--- a/Tests/Performance/UiFixtureFactory.cs
+++ b/Tests/Performance/UiFixtureFactory.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2023-2026 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TestHelper.UI.Performance
+{
+    // Fixtures are built in code instead of scene files so that object count and hierarchy depth are tunable
+    // without maintaining large scene assets.
+    internal static class UiFixtureFactory
+    {
+        public static void CreateNestedButtons(int count, int nestDepth)
+        {
+            var canvas = CreateCanvas();
+            for (var i = 0; i < count; i++)
+            {
+                var parent = canvas.transform;
+                for (var depth = 0; depth < nestDepth; depth++)
+                {
+                    var nest = new GameObject("Nest");
+                    nest.transform.SetParent(parent, false);
+                    parent = nest.transform;
+                }
+
+                CreateButton(parent, $"Button_{i}", withImage: false);
+            }
+        }
+
+        public static void CreateGridButtons(int count)
+        {
+            const int Columns = 5;
+            const float CellWidth = 110f;
+            const float CellHeight = 40f;
+
+            var canvas = CreateCanvas();
+            var rows = (count + Columns - 1) / Columns;
+            for (var i = 0; i < count; i++)
+            {
+                var column = i % Columns;
+                var row = i / Columns;
+                var button = CreateButton(canvas.transform, $"Button_{i}", withImage: true);
+                var rectTransform = (RectTransform)button.transform;
+                rectTransform.sizeDelta = new Vector2(100f, 30f);
+                rectTransform.anchoredPosition = new Vector2(
+                    (column - (Columns - 1) * 0.5f) * CellWidth,
+                    (row - (rows - 1) * 0.5f) * CellHeight);
+            }
+        }
+
+        private static Canvas CreateCanvas()
+        {
+            var canvas = new GameObject("Canvas", typeof(Canvas), typeof(GraphicRaycaster)).GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            _ = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            return canvas;
+        }
+
+        private static GameObject CreateButton(Transform parent, string name, bool withImage)
+        {
+            // An Image is attached only when the button must be hit by GraphicRaycaster (reachability check);
+            // matcher-scan fixtures omit it to keep setup light. No Font is assigned to the Text because
+            // nothing needs to render; matchers only read the text string.
+            var button = withImage
+                ? new GameObject(name, typeof(Image), typeof(Button))
+                : new GameObject(name, typeof(RectTransform), typeof(Button));
+            button.transform.SetParent(parent, false);
+
+            var text = new GameObject("Text", typeof(Text));
+            text.transform.SetParent(button.transform, false);
+            text.GetComponent<Text>().text = name;
+
+            return button;
+        }
+    }
+}

--- a/Tests/Performance/UiFixtureFactory.cs.meta
+++ b/Tests/Performance/UiFixtureFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ceb6e9bf515e46108789c195ca5a592


### PR DESCRIPTION
## Summary

Rework the performance tests under `Tests/Performance` so they produce numbers comparable across branches — primarily to measure the effect of runtime optimization branches such as replacing player-loop-unsafe APIs (#318).

The previous measurements were not usable for comparison:

- `GetLotteryEntries_GotAllInteractableComponentAndOperators` never enumerated the returned iterator, so the measured block executed no production code.
- `LotteryOperator_BingoReachableComponent` passed a lazy enumerable, so the finder's full enumeration ran inside the measured block on every iteration.
- `RunStep_finish` selected operators at random, so no two runs shared a workload.

## Changes

- **Rewrite `MonkeyTest.RunStep_SeededRandom_MeasureTimeAndAllocations`**: pinned random seed, code-generated grid of reachable buttons, and only `UguiClickOperator` registered so operator hold times do not dominate the samples.
- **Add `GameObjectFinderTest`** with three measurements:
  - `FindByMatcherAsync` with `ButtonMatcher` scanning 1,000 buttons, each nested 10 GameObjects deep (~12,000 objects)
  - `FindByNameAsync` on the identical hierarchy, to compare name matching against component-gated matching
  - `FindByMatcherAsync` with `UguiScrollRectPaginator` in `ScrollViews.unity`, targeting the last button so every iteration sweeps all pages
- **Add `PerformanceMeasurement`**: `Measure.Method().GC()` only accepts synchronous delegates, so async APIs are sampled manually via `Measure.Custom` — Stopwatch for Time and managed heap growth (`GC.GetTotalMemory`) for GC.Alloc. The two counters that look like the obvious choice are both dead in an Editor test run, so the helper documents why it avoids them:
  - `GC.GetAllocatedBytesForCurrentThread()` is a stub on Unity's Mono runtime — allocating 1 MB moves it by 0 bytes, so it reports "no allocations" for everything instead of failing.
  - `ProfilerRecorder(ProfilerCategory.Memory, "GC.Alloc")` (what `Measure.Method().GC()` uses) only yields data while the Profiler is recording. `Profiler.enabled` is false in a plain Editor test run — which is how CI runs these — and it then reports unrelated values: a 1 MB allocation is indistinguishable from an idle frame.
  - The helper asserts the counter actually moves (`Assume`) before sampling, so a dead counter fails the test instead of silently reporting zeros.
- **Add `UiFixtureFactory`**: fixtures are built in code so object count and nesting depth are tunable without maintaining large scene assets.
- **Drop the `[Version]` attribute** and its constant, which were not functioning in reports.
- Enable performance testing on CI.

## How to compare a runtime branch

Since the test changes touch only `Tests/Performance`, run the tests as-is for the baseline, then re-run with the runtime swapped in:

```bash
git checkout <runtime-branch> -- Runtime/   # measure
git checkout master -- Runtime/             # restore
```

Compare the Median of the Time and GC.Alloc sample groups per test. Note that GC.Alloc samples are managed heap growth, which the heap serves in pages — an allocation that fits in already-reserved space reads as 0. Treat the samples as a relative measure between branches, not as an exact byte count for one operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
