### PR TITLE
Resolve warning-level diagnostics and tighten analyzer config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,9 +147,6 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 file_header_template = Copyright (c) 2023-${CurrentDate.Year} Koji Hasegawa.\nThis software is released under the MIT License.
 
-# RS0016: Only enable if API files are present
-dotnet_public_api_analyzer.require_api_files = true
-
 # IDE0055: Fix formatting
 # Workaround for https://github.com/dotnet/roslyn/issues/70570
 dotnet_diagnostic.IDE0055.severity = warning
@@ -180,6 +177,8 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
+
+# Attributes are not on the same line
 csharp_place_type_attribute_on_same_line = false
 csharp_place_method_attribute_on_same_line = false
 csharp_place_accessorholder_attribute_on_same_line = false
@@ -263,6 +262,39 @@ resharper_csharp_keep_existing_initializer_arrangement = true
 
 # Some values of the enum are not processed inside 'switch' statement and are handled via default section
 resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
+
+# Must call where another overload of the same method accepts a CancellationToken if a suitable token is already available in the current scope
+resharper_method_supports_cancellation_highlighting = warning
+
+# Must use Array.Empty<T>() instead of a zero-length array creation expression, which allocates a new array on every evaluation
+resharper_use_array_empty_method_highlighting = warning
+
+# Must use the 'is' operator instead of Type.IsInstanceOfType, which performs the type check through reflection at run time
+resharper_can_simplify_is_instance_of_type_highlighting = warning
+
+# Must use the 'is' operator instead of Type.IsAssignableFrom against a known type, which performs the type check through reflection at run time
+resharper_can_simplify_is_assignable_from_highlighting = warning
+
+# Must use TryGetValue instead of checking ContainsKey and then reading through the indexer
+resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting = warning
+
+# Must use TryAdd instead of checking ContainsKey and then calling Add
+resharper_can_simplify_dictionary_lookup_with_try_add_highlighting = warning
+
+# Must call Remove directly and inspect its return value instead of checking ContainsKey first
+resharper_can_simplify_dictionary_removing_with_single_call_highlighting = warning
+
+# Must call Add directly and inspect its return value instead of checking Contains first
+resharper_can_simplify_set_adding_with_single_call_highlighting = warning
+
+# Must declare a non-mutating struct as readonly so that the compiler stops emitting defensive copies when its members are invoked through readonly references
+resharper_struct_can_be_made_read_only_highlighting = warning
+
+# Type and member is never used (for coding agents)
+resharper_unused_type_local_highlighting = warning
+resharper_unused_type_global_highlighting = warning
+resharper_unused_member_global_highlighting = warning
+resharper_unused_member_local_highlighting = warning
 
 # Suppress C#8.0+ syntax sugar (for under Unity 2020.2 compatibility)
 # See: https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html

--- a/.editorconfig
+++ b/.editorconfig
@@ -266,26 +266,11 @@ resharper_switch_statement_handles_some_known_enum_values_with_default_highlight
 # Must call where another overload of the same method accepts a CancellationToken if a suitable token is already available in the current scope
 resharper_method_supports_cancellation_highlighting = warning
 
-# Must use Array.Empty<T>() instead of a zero-length array creation expression, which allocates a new array on every evaluation
-resharper_use_array_empty_method_highlighting = warning
-
 # Must use the 'is' operator instead of Type.IsInstanceOfType, which performs the type check through reflection at run time
 resharper_can_simplify_is_instance_of_type_highlighting = warning
 
 # Must use the 'is' operator instead of Type.IsAssignableFrom against a known type, which performs the type check through reflection at run time
 resharper_can_simplify_is_assignable_from_highlighting = warning
-
-# Must use TryGetValue instead of checking ContainsKey and then reading through the indexer
-resharper_can_simplify_dictionary_lookup_with_try_get_value_highlighting = warning
-
-# Must use TryAdd instead of checking ContainsKey and then calling Add
-resharper_can_simplify_dictionary_lookup_with_try_add_highlighting = warning
-
-# Must call Remove directly and inspect its return value instead of checking ContainsKey first
-resharper_can_simplify_dictionary_removing_with_single_call_highlighting = warning
-
-# Must call Add directly and inspect its return value instead of checking Contains first
-resharper_can_simplify_set_adding_with_single_call_highlighting = warning
 
 # Must declare a non-mutating struct as readonly so that the compiler stops emitting defensive copies when its members are invoked through readonly references
 resharper_struct_can_be_made_read_only_highlighting = warning

--- a/Annotations/TestHelper.UI.Annotations.globalconfig
+++ b/Annotations/TestHelper.UI.Annotations.globalconfig
@@ -27,7 +27,7 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Annotations/TestHelper.UI.Annotations.globalconfig
+++ b/Annotations/TestHelper.UI.Annotations.globalconfig
@@ -6,6 +6,29 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Annotations/TestHelper.UI.Annotations.globalconfig
+++ b/Annotations/TestHelper.UI.Annotations.globalconfig
@@ -6,6 +6,12 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Annotations/TestHelper.UI.Annotations.globalconfig
+++ b/Annotations/TestHelper.UI.Annotations.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Annotations/TestHelper.UI.Annotations.globalconfig
+++ b/Annotations/TestHelper.UI.Annotations.globalconfig
@@ -27,13 +27,13 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Editor/TestHelper.UI.Editor.globalconfig
+++ b/Editor/TestHelper.UI.Editor.globalconfig
@@ -27,7 +27,7 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Editor/TestHelper.UI.Editor.globalconfig
+++ b/Editor/TestHelper.UI.Editor.globalconfig
@@ -6,6 +6,29 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Editor/TestHelper.UI.Editor.globalconfig
+++ b/Editor/TestHelper.UI.Editor.globalconfig
@@ -6,6 +6,12 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Editor/TestHelper.UI.Editor.globalconfig
+++ b/Editor/TestHelper.UI.Editor.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Editor/TestHelper.UI.Editor.globalconfig
+++ b/Editor/TestHelper.UI.Editor.globalconfig
@@ -27,13 +27,13 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
+++ b/Editor/UI/Hints/InteractiveComponentHintGizmoDrawer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using TestHelper.UI;
 using TestHelper.UI.Hints;
 using UnityEditor;
 using UnityEngine;

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -47,7 +47,7 @@ namespace TestHelper.UI
             if (timeoutSeconds < MinTimeoutSeconds)
             {
                 throw new ArgumentException(
-                    $"Must be greater than or equal to {MinTimeoutSeconds}.", nameof(timeoutSeconds));
+                    $"Must be greater than or equal to {MinTimeoutSeconds.ToString()}.", nameof(timeoutSeconds));
             }
 
             _timeoutSeconds = timeoutSeconds;
@@ -325,12 +325,12 @@ namespace TestHelper.UI
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Found <c>GameObject</c> and the frontmost raycast hit result will be set regardless of whether the event can be processed</returns>
         /// <exception cref="TimeoutException">Throws if <c>GameObject</c> is not found</exception>
-        public async UniTask<GameObjectFinderResult> FindByNameAsync(string name, bool reachable = true,
+        public UniTask<GameObjectFinderResult> FindByNameAsync(string name, bool reachable = true,
             bool interactable = false, IPaginator paginator = null, double timeoutSeconds = 0,
             CancellationToken cancellationToken = default)
         {
             var matcher = new NameMatcher(name);
-            return await FindByMatcherAsync(matcher, reachable, interactable, paginator, timeoutSeconds,
+            return FindByMatcherAsync(matcher, reachable, interactable, paginator, timeoutSeconds,
                 cancellationToken);
         }
 
@@ -346,12 +346,12 @@ namespace TestHelper.UI
         /// <returns>Found <c>GameObject</c> and the frontmost raycast hit result will be set regardless of whether the event can be processed</returns>
         /// <exception cref="TimeoutException">Throws if <c>GameObject</c> is not found</exception>
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
-        public async UniTask<GameObjectFinderResult> FindByPathAsync(string path, bool reachable = true,
+        public UniTask<GameObjectFinderResult> FindByPathAsync(string path, bool reachable = true,
             bool interactable = false, IPaginator paginator = null, double timeoutSeconds = 0,
             CancellationToken cancellationToken = default)
         {
             var matcher = new PathMatcher(path);
-            return await FindByMatcherAsync(matcher, reachable, interactable, paginator, timeoutSeconds,
+            return FindByMatcherAsync(matcher, reachable, interactable, paginator, timeoutSeconds,
                 cancellationToken);
         }
     }

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using TestHelper.UI.Exceptions;
@@ -47,7 +48,8 @@ namespace TestHelper.UI
             if (timeoutSeconds < MinTimeoutSeconds)
             {
                 throw new ArgumentException(
-                    $"Must be greater than or equal to {MinTimeoutSeconds.ToString()}.", nameof(timeoutSeconds));
+                    $"Must be greater than or equal to {MinTimeoutSeconds.ToString(CultureInfo.InvariantCulture)}.",
+                    nameof(timeoutSeconds));
             }
 
             _timeoutSeconds = timeoutSeconds;

--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -19,6 +19,7 @@ using UnityEngine.EventSystems;
 using TestHelper.UI.Extensions;
 #if UNITY_6000_4_OR_NEWER
 using InstanceIdentifier = UnityEngine.EntityId;
+
 #else
 using InstanceIdentifier = System.Int32;
 #endif

--- a/Runtime/Monkey.cs
+++ b/Runtime/Monkey.cs
@@ -114,7 +114,7 @@ namespace TestHelper.UI
                     {
                         // No interactive component found
                         var message = new StringBuilder(
-                            $"Interactive component not found in {config.SecondsToErrorForNoInteractiveComponent} seconds");
+                            $"Interactive component not found in {config.SecondsToErrorForNoInteractiveComponent.ToString()} seconds");
                         await TakeScreenshotAsync(config.Screenshots, message);
                         throw new TimeoutException(message.ToString());
                     }
@@ -237,7 +237,7 @@ namespace TestHelper.UI
                 if (verboseLogger != null)
                 {
                     lotteryEntries.Append(
-                        $"{gameObject.name}({gameObject.GetId()}):{component.GetType().Name}:{@operator.GetType().Name}, ");
+                        $"{gameObject.name}({gameObject.GetId().ToString()}):{component.GetType().Name}:{@operator.GetType().Name}, ");
                 }
 
                 yield return (gameObject, @operator);

--- a/Runtime/Operators/UguiDragAndDropOperator.cs
+++ b/Runtime/Operators/UguiDragAndDropOperator.cs
@@ -254,7 +254,7 @@ namespace TestHelper.UI.Operators
                 {
                     var builder = new StringBuilder();
                     builder.Append($"{this.GetType().Name} drop to {dropGameObject.name}");
-                    builder.Append($"({dropGameObject.GetId()})");
+                    builder.Append($"({dropGameObject.GetId().ToString()})");
                     builder.Append($", position={Format(dropPosition)}");
                     Logger.Log(builder.ToString());
                 }

--- a/Runtime/Operators/UguiScrollWheelOperator.cs
+++ b/Runtime/Operators/UguiScrollWheelOperator.cs
@@ -16,6 +16,7 @@ using UnityEngine.UI;
 // System.MathF requires .NET Standard 2.1 (Unity 2021.2 or newer); aliased so that call sites need no directives.
 #if UNITY_2021_2_OR_NEWER
 using MathF = System.MathF;
+
 #else
 using MathF = UnityEngine.Mathf;
 #endif

--- a/Runtime/Operators/Utils/OperationLogger.cs
+++ b/Runtime/Operators/Utils/OperationLogger.cs
@@ -100,7 +100,7 @@ namespace TestHelper.UI.Operators.Utils
             }
             else
             {
-                builder.Append($"({_gameObject.GetId()})");
+                builder.Append($"({_gameObject.GetId().ToString()})");
             }
 
             if (Properties.Count > 0)

--- a/Runtime/Paginators/UguiScrollRectPaginator.cs
+++ b/Runtime/Paginators/UguiScrollRectPaginator.cs
@@ -9,6 +9,7 @@ using UnityEngine.UI;
 // System.MathF requires .NET Standard 2.1 (Unity 2021.2 or newer); aliased so that call sites need no directives.
 #if UNITY_2021_2_OR_NEWER
 using MathF = System.MathF;
+
 #else
 using MathF = UnityEngine.Mathf;
 #endif

--- a/Runtime/Paginators/UguiScrollbarPaginator.cs
+++ b/Runtime/Paginators/UguiScrollbarPaginator.cs
@@ -8,6 +8,7 @@ using UnityEngine.UI;
 // System.MathF requires .NET Standard 2.1 (Unity 2021.2 or newer); aliased so that call sites need no directives.
 #if UNITY_2021_2_OR_NEWER
 using MathF = System.MathF;
+
 #else
 using MathF = UnityEngine.Mathf;
 #endif

--- a/Runtime/Strategies/DefaultIgnoreStrategy.cs
+++ b/Runtime/Strategies/DefaultIgnoreStrategy.cs
@@ -44,7 +44,7 @@ namespace TestHelper.UI.Strategies
                             IsMatchedOrChildOfIgnoreMatchersMatched(gameObject);
             if (isIgnored && verboseLogger != null)
             {
-                verboseLogger.Log($"Ignored {gameObject.name}({gameObject.GetId()}).");
+                verboseLogger.Log($"Ignored {gameObject.name}({gameObject.GetId().ToString()}).");
             }
 
             return isIgnored;

--- a/Runtime/Strategies/DefaultReachableStrategy.cs
+++ b/Runtime/Strategies/DefaultReachableStrategy.cs
@@ -96,7 +96,7 @@ namespace TestHelper.UI.Strategies
                 message.Append(" Raycast hit other objects: [");
                 foreach (var result in _results)
                 {
-                    message.Append($"{result.gameObject.name}({result.gameObject.GetId()})");
+                    message.Append($"{result.gameObject.name}({result.gameObject.GetId().ToString()})");
                     message.Append(", ");
                 }
 
@@ -164,12 +164,13 @@ namespace TestHelper.UI.Strategies
             var x = (int)position.x;
             var y = (int)position.y;
             var builder = new StringBuilder();
-            builder.Append($"Not reachable to {gameObject.name}({gameObject.GetId()}), position=({x},{y})");
+            builder.Append(
+                $"Not reachable to {gameObject.name}({gameObject.GetId().ToString()}), position=({x.ToString()},{y.ToString()})");
 
             var camera = gameObject.GetAssociatedCamera();
             if (camera != null)
             {
-                builder.Append($", camera={camera.name}({camera.GetId()})");
+                builder.Append($", camera={camera.name}({camera.GetId().ToString()})");
             }
 
             builder.Append(".");

--- a/Runtime/TestHelper.UI.globalconfig
+++ b/Runtime/TestHelper.UI.globalconfig
@@ -27,7 +27,7 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Runtime/TestHelper.UI.globalconfig
+++ b/Runtime/TestHelper.UI.globalconfig
@@ -6,6 +6,29 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Runtime/TestHelper.UI.globalconfig
+++ b/Runtime/TestHelper.UI.globalconfig
@@ -6,6 +6,12 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# Microsoft.CodeAnalysis.NetAnalyzers categories
+dotnet_analyzer_diagnostic.category-Design.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
+dotnet_analyzer_diagnostic.category-Naming.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Runtime/TestHelper.UI.globalconfig
+++ b/Runtime/TestHelper.UI.globalconfig
@@ -12,6 +12,12 @@ dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
 dotnet_analyzer_diagnostic.category-Naming.severity = warning
 dotnet_analyzer_diagnostic.category-Performance.severity = warning
 
+# CA1016: Mark assemblies with assembly version; Not for Unity
+dotnet_diagnostic.CA1016.severity = none
+
+# CA1051: Do not declare visible instance fields; Not for Unity
+dotnet_diagnostic.CA1051.severity = none
+
 # RCS1174: Remove redundant async/await
 dotnet_diagnostic.RCS1174.severity = warning
 

--- a/Runtime/TestHelper.UI.globalconfig
+++ b/Runtime/TestHelper.UI.globalconfig
@@ -27,13 +27,13 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Runtime/Visualizers/FadeOutBehaviour.cs
+++ b/Runtime/Visualizers/FadeOutBehaviour.cs
@@ -7,6 +7,7 @@ using UnityEngine.UI;
 // System.MathF requires .NET Standard 2.1 (Unity 2021.2 or newer); aliased so that call sites need no directives.
 #if UNITY_2021_2_OR_NEWER
 using MathF = System.MathF;
+
 #else
 using MathF = UnityEngine.Mathf;
 #endif

--- a/Samples~/uGUI Demo/Scripts/Runtime/TestHelper.UI.Samples.UguiDemo.globalconfig
+++ b/Samples~/uGUI Demo/Scripts/Runtime/TestHelper.UI.Samples.UguiDemo.globalconfig
@@ -21,7 +21,7 @@ dotnet_diagnostic.UNT0023.severity = warning
 # UNT0030: Calling Destroy or DestroyImmediate on a Transform
 dotnet_diagnostic.UNT0030.severity = warning
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)

--- a/Samples~/uGUI Demo/Scripts/Runtime/TestHelper.UI.Samples.UguiDemo.globalconfig
+++ b/Samples~/uGUI Demo/Scripts/Runtime/TestHelper.UI.Samples.UguiDemo.globalconfig
@@ -6,6 +6,24 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = error
 
+# RCS1174: Remove redundant async/await
+dotnet_diagnostic.RCS1174.severity = warning
+
+# RCS1198: Avoid unnecessary boxing of value type
+dotnet_diagnostic.RCS1198.severity = warning
+
+# UNT0009: Missing static constructor with InitializeOnLoad attribute
+dotnet_diagnostic.UNT0009.severity = warning
+
+# UNT0023: Coalescing assignment on Unity objects
+dotnet_diagnostic.UNT0023.severity = warning
+
+# UNT0030: Calling Destroy or DestroyImmediate on a Transform
+dotnet_diagnostic.UNT0030.severity = warning
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none

--- a/Samples~/uGUI Demo/Tests/Runtime/TestHelper.UI.Samples.UguiDemo.Tests.globalconfig
+++ b/Samples~/uGUI Demo/Tests/Runtime/TestHelper.UI.Samples.UguiDemo.Tests.globalconfig
@@ -61,8 +61,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
@@ -6,7 +6,7 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
+++ b/Tests/Editor/TestHelper.UI.Editor.Tests.globalconfig
@@ -6,13 +6,13 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Tests/Editor/Validators/SceneValidator.cs
+++ b/Tests/Editor/Validators/SceneValidator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ namespace TestHelper.UI.Editor.Validators
     public class SceneValidator
     {
         private static IEnumerable<TestCaseData> Scenes => AssetDatabase
-            .FindAssets("t:SceneAsset", new string[] { "Packages/com.nowsprinting.test-helper.ui" })
+            .FindAssets("t:SceneAsset", new[] { "Packages/com.nowsprinting.test-helper.ui" })
             .Select(AssetDatabase.GUIDToAssetPath)
             .Select(path => new TestCaseData(path).SetName(Path.GetFileName(path)));
 

--- a/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
+++ b/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
+++ b/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
@@ -6,7 +6,7 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
+++ b/Tests/Performance/TestHelper.UI.Performance.Tests.globalconfig
@@ -6,13 +6,13 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Tests/Runtime/Annotations/PositionAnnotationTest.cs
+++ b/Tests/Runtime/Annotations/PositionAnnotationTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -14,7 +14,7 @@ using UnityEngine;
 namespace TestHelper.UI.Annotations
 {
     [TestFixture]
-    public class PositionAnnotationTest
+    public static class PositionAnnotationTest
     {
         [TestFixture]
         public class NotOnScaledCanvas

--- a/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
+++ b/Tests/Runtime/Extensions/GameObjectExtensionsTest.cs
@@ -6,10 +6,6 @@ using TestHelper.Attributes;
 using TestHelper.UI.TestDoubles;
 using UnityEngine;
 using UnityEngine.UI;
-#if !UNITY_2023_1_OR_NEWER
-using System.Linq;
-using Cysharp.Threading.Tasks;
-#endif
 
 namespace TestHelper.UI.Extensions
 {

--- a/Tests/Runtime/GameObjectFinderTest.cs
+++ b/Tests/Runtime/GameObjectFinderTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -511,8 +511,10 @@ namespace TestHelper.UI
             [TearDown]
             public async Task TearDown()
             {
-                await UniTask.Delay(TimeSpan.FromSeconds(IndicatorLifetime)); // game-time wait (same basis as FadeOutBehaviour)
-                await UniTask.DelayFrame(1); // one extra frame to ensure FadeOutBehaviour.Update() calls OnFadeOutCompleted
+                await UniTask.Delay(
+                    TimeSpan.FromSeconds(IndicatorLifetime)); // game-time wait (same basis as FadeOutBehaviour)
+                await UniTask
+                    .DelayFrame(1); // one extra frame to ensure FadeOutBehaviour.Update() calls OnFadeOutCompleted
             }
 
             [Test]

--- a/Tests/Runtime/GameObjectFinderTest.cs
+++ b/Tests/Runtime/GameObjectFinderTest.cs
@@ -24,10 +24,6 @@ using Is = TestHelper.Constraints.Is;
 using System.IO;
 #endif
 
-#if !UNITY_2023_1_OR_NEWER
-using Cysharp.Threading.Tasks;
-#endif
-
 namespace TestHelper.UI
 {
     [TestFixture]

--- a/Tests/Runtime/InteractableComponentsFinderTest.cs
+++ b/Tests/Runtime/InteractableComponentsFinderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023-2025 Koji Hasegawa.
+﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using UnityEngine.UI;
 namespace TestHelper.UI
 {
     [TestFixture]
-    public class InteractableComponentsFinderTest
+    public static class InteractableComponentsFinderTest
     {
         /// <summary>
         /// InteractableComponentsFinder test cases using 3D objects
@@ -91,7 +91,7 @@ namespace TestHelper.UI
         }
 
         [TestFixture]
-        public class UI
+        public static class UI
         {
             private static readonly string[] s_reachableUiObjects =
             {

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023-2025 Koji Hasegawa.
+﻿// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -629,8 +629,10 @@ namespace TestHelper.UI
             [TearDown]
             public async Task TearDown()
             {
-                await UniTask.Delay(TimeSpan.FromSeconds(IndicatorLifetime)); // game-time wait (same basis as FadeOutBehaviour)
-                await UniTask.DelayFrame(1); // one extra frame to ensure FadeOutBehaviour.Update() calls OnFadeOutCompleted
+                await UniTask.Delay(
+                    TimeSpan.FromSeconds(IndicatorLifetime)); // game-time wait (same basis as FadeOutBehaviour)
+                await UniTask
+                    .DelayFrame(1); // one extra frame to ensure FadeOutBehaviour.Update() calls OnFadeOutCompleted
             }
 
             [Test]
@@ -663,7 +665,7 @@ namespace TestHelper.UI
                 var blocker = GameObject.CreatePrimitive(PrimitiveType.Quad);
                 blocker.transform.position = new Vector3(0, 1, -7);
                 blocker.GetComponent<MeshRenderer>().materials[0].color = Color.gray;
-                Physics.SyncTransforms(); // sync collider positions before PhysicsRaycaster queries
+                Physics.SyncTransforms();    // sync collider positions before PhysicsRaycaster queries
                 await UniTask.DelayFrame(5); // warm up for physics raycaster
 
                 var operators = new List<(GameObject, IOperator)> { (cube, new UguiClickOperator()), };

--- a/Tests/Runtime/MonkeyTest.cs
+++ b/Tests/Runtime/MonkeyTest.cs
@@ -558,7 +558,7 @@ namespace TestHelper.UI
                 var spyLogger = new SpyLogger();
                 var ignoreStrategy = new DefaultIgnoreStrategy(verboseLogger: spyLogger);
                 var reachableStrategy = new DefaultReachableStrategy(verboseLogger: spyLogger);
-                Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
+                _ = Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
 
                 Assert.That(spyLogger.Messages, Has.Count.EqualTo(1));
                 Assert.That(spyLogger.Messages[0], Is.EqualTo("Lottery entries are empty or all of not reachable."));
@@ -578,7 +578,7 @@ namespace TestHelper.UI
                 var spyLogger = new SpyLogger();
                 var ignoreStrategy = new DefaultIgnoreStrategy(verboseLogger: spyLogger);
                 var reachableStrategy = new DefaultReachableStrategy(verboseLogger: spyLogger);
-                Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
+                _ = Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
 
                 Assert.That(spyLogger.Messages, Has.Count.EqualTo(2));
                 Assert.That(spyLogger.Messages[0], Does.Match(@"Ignored Cube\([^)]+\)."));
@@ -598,7 +598,7 @@ namespace TestHelper.UI
                 var spyLogger = new SpyLogger();
                 var ignoreStrategy = new DefaultIgnoreStrategy(verboseLogger: spyLogger);
                 var reachableStrategy = new DefaultReachableStrategy(verboseLogger: spyLogger);
-                Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
+                _ = Monkey.LotteryOperator(operators, random, ignoreStrategy, reachableStrategy, spyLogger);
 
                 Assert.That(spyLogger.Messages, Has.Count.EqualTo(2));
                 Assert.That(spyLogger.Messages[0],

--- a/Tests/Runtime/Operators/UguiTextInputOperatorTest.cs
+++ b/Tests/Runtime/Operators/UguiTextInputOperatorTest.cs
@@ -1,6 +1,7 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System.Threading.Tasks;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using TestHelper.UI.TestDoubles;
@@ -99,63 +100,63 @@ namespace TestHelper.UI.Operators
         }
 
         [Test]
-        public void OperateAsync_InputField_SetsRandomText()
+        public async Task OperateAsync_InputField_SetsRandomText()
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<InputField>();
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
-            _sut.OperateAsync(gameObject);
+            await _sut.OperateAsync(gameObject);
 
             Assert.That(inputField.text, Is.EqualTo("RANDOM"));
         }
 
         [Test]
-        public void OperateAsync_InputFieldWithText_SetsSpecifiedText()
+        public async Task OperateAsync_InputFieldWithText_SetsSpecifiedText()
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<InputField>();
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
-            _sut.OperateAsync(gameObject, "SPECIFIED");
+            await _sut.OperateAsync(gameObject, "SPECIFIED");
 
             Assert.That(inputField.text, Is.EqualTo("SPECIFIED"));
         }
 
         [Test]
-        public void OperateAsync_TmpInputField_SetsRandomText()
+        public async Task OperateAsync_TmpInputField_SetsRandomText()
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<TMP_InputField>();
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
-            _sut.OperateAsync(gameObject);
+            await _sut.OperateAsync(gameObject);
 
             Assert.That(inputField.text, Is.EqualTo("RANDOM"));
         }
 
         [Test]
-        public void OperateAsync_TmpInputFieldWithText_SetsSpecifiedText()
+        public async Task OperateAsync_TmpInputFieldWithText_SetsSpecifiedText()
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<TMP_InputField>();
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
-            _sut.OperateAsync(gameObject, "SPECIFIED");
+            await _sut.OperateAsync(gameObject, "SPECIFIED");
 
             Assert.That(inputField.text, Is.EqualTo("SPECIFIED"));
         }
 
         [Test]
-        public void OperateAsync_TmpInputFieldWithValidator_SetsValidatedText()
+        public async Task OperateAsync_TmpInputFieldWithValidator_SetsValidatedText()
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<TMP_InputField>();
-            inputField.onValidateInput += (string text, int index, char addedChar) =>
+            inputField.onValidateInput += (_, _, addedChar) =>
                 addedChar != 'N' ? addedChar : '\0';
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
-            _sut.OperateAsync(gameObject);
+            await _sut.OperateAsync(gameObject);
 
             Assert.That(inputField.text, Is.EqualTo("RADOM"));
         }

--- a/Tests/Runtime/Operators/UguiTextInputOperatorTest.cs
+++ b/Tests/Runtime/Operators/UguiTextInputOperatorTest.cs
@@ -152,8 +152,14 @@ namespace TestHelper.UI.Operators
         {
             var gameObject = new GameObject();
             var inputField = gameObject.AddComponent<TMP_InputField>();
-            inputField.onValidateInput += (_, _, addedChar) =>
+            // TMP_InputField.onValidateInput requires all 3 parameters; only addedChar is used here.
+            // Discard parameters (`_, _`) require C# 9, unavailable under this package's C# 7.3 target.
+            // ReSharper disable UnusedParameter.Local
+#pragma warning disable RCS1163 // Unused parameter
+            inputField.onValidateInput += (text, index, addedChar) =>
                 addedChar != 'N' ? addedChar : '\0';
+#pragma warning restore RCS1163
+            // ReSharper restore UnusedParameter.Local
 
             Assume.That(_sut.CanOperate(gameObject), Is.True);
             await _sut.OperateAsync(gameObject);

--- a/Tests/Runtime/Operators/Utils/FingerPoolTest.cs
+++ b/Tests/Runtime/Operators/Utils/FingerPoolTest.cs
@@ -36,7 +36,7 @@ namespace TestHelper.UI.Operators.Utils
         public void Acquire_AfterReleaseFirstId_ReusesReleasedId()
         {
             var id0 = FingerPool.Instance.Acquire();
-            var id1 = FingerPool.Instance.Acquire();
+            FingerPool.Instance.Acquire(); // 1
             FingerPool.Instance.Release(id0);
 
             var actual = FingerPool.Instance.Acquire();
@@ -47,9 +47,9 @@ namespace TestHelper.UI.Operators.Utils
         [Test]
         public void Acquire_AfterReleaseMiddleId_ReusesReleasedId()
         {
-            var id0 = FingerPool.Instance.Acquire();
+            FingerPool.Instance.Acquire(); // 0
             var id1 = FingerPool.Instance.Acquire();
-            var id2 = FingerPool.Instance.Acquire();
+            FingerPool.Instance.Acquire(); // 2
             FingerPool.Instance.Release(id1);
 
             var actual = FingerPool.Instance.Acquire();
@@ -60,7 +60,7 @@ namespace TestHelper.UI.Operators.Utils
         [Test]
         public void Release_NotAcquiredId_DoesNotAffectPool()
         {
-            var id0 = FingerPool.Instance.Acquire();
+            FingerPool.Instance.Acquire();    // 0
             FingerPool.Instance.Release(999); // no error should occur
 
             var actual = FingerPool.Instance.Acquire();
@@ -71,7 +71,7 @@ namespace TestHelper.UI.Operators.Utils
         [Test]
         public void Acquire_AfterReleaseLastId_ReusesSameId()
         {
-            var id0 = FingerPool.Instance.Acquire();
+            FingerPool.Instance.Acquire(); // 0
             var id1 = FingerPool.Instance.Acquire();
             FingerPool.Instance.Release(id1);
 

--- a/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs
+++ b/Tests/Runtime/Operators/Utils/SimulatedPointerEventDataTest.cs
@@ -1,14 +1,12 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace TestHelper.UI.Operators.Utils
 {
-    [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP017:Prefer using")]
     public class SimulatedPointerEventDataTest
     {
         [SetUp]

--- a/Tests/Runtime/ScreenshotFilenameStrategies/CounterBasedStrategyTest.cs
+++ b/Tests/Runtime/ScreenshotFilenameStrategies/CounterBasedStrategyTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -31,7 +31,7 @@ namespace TestHelper.UI.ScreenshotFilenameStrategies
         [Test]
         public void DefaultFilenamePrefix()
         {
-            var strategy = new CounterBasedStrategy(null);
+            var strategy = new CounterBasedStrategy();
 
             var actual = Enumerable.Repeat(0, 5).Select(_ => strategy.GetFilename()).ToList();
             var expected = new List<string>

--- a/Tests/Runtime/Strategies/DefaultReachableStrategyTest.cs
+++ b/Tests/Runtime/Strategies/DefaultReachableStrategyTest.cs
@@ -12,7 +12,8 @@ using TestHelper.UI.TestDoubles;
 using UnityEngine;
 using UnityEngine.TestTools;
 #if !UNITY_2023_1_OR_NEWER
-using System.Linq;
+// Unity 2023.1 or newer provides the awaiter for AsyncOperation;
+// on older versions it comes from UniTask.
 using Cysharp.Threading.Tasks;
 #endif
 

--- a/Tests/Runtime/Strategies/DefaultReachableStrategyTest.cs
+++ b/Tests/Runtime/Strategies/DefaultReachableStrategyTest.cs
@@ -19,7 +19,7 @@ using Cysharp.Threading.Tasks;
 namespace TestHelper.UI.Strategies
 {
     [TestFixture]
-    public class DefaultReachableStrategyTest
+    public static class DefaultReachableStrategyTest
     {
         [TestFixture(RenderMode.ScreenSpaceOverlay)]
         [TestFixture(RenderMode.ScreenSpaceCamera)]

--- a/Tests/Runtime/TestComponents/RelayButton.cs
+++ b/Tests/Runtime/TestComponents/RelayButton.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using UnityEngine;
@@ -14,7 +14,7 @@ namespace TestHelper.UI.TestComponents
         public Button NextButton { get; private set; }
 
         [field: SerializeField]
-        public bool EnabledOnLoad { get; set; } = false;
+        public bool EnabledOnLoad { get; set; }
 
         private Button _button;
 

--- a/Tests/Runtime/TestDoubles/FakeOperatorWithoutPublicConstructor.cs
+++ b/Tests/Runtime/TestDoubles/FakeOperatorWithoutPublicConstructor.cs
@@ -13,6 +13,9 @@ using UnityEngine.EventSystems;
 namespace TestHelper.UI.TestDoubles
 {
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+    // Intentionally has no public constructor: this fake verifies that OperatorPool rejects
+    // registering an IOperator type without one, so it must stay non-instantiable directly.
+    [SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
     public class FakeOperatorWithoutPublicConstructor : IOperator
     {
         public ILogger Logger { get; set; }

--- a/Tests/Runtime/TestHelper.UI.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.UI.Tests.globalconfig
@@ -6,6 +6,14 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
+# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# IDISP017: Prefer using
+# The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
+# supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
+dotnet_diagnostic.IDISP017.severity = none
+
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none
 dotnet_diagnostic.CS8600.severity = none
@@ -61,8 +69,8 @@ dotnet_diagnostic.CS8824.severity = none
 dotnet_diagnostic.CS8825.severity = none
 dotnet_diagnostic.CS8847.severity = none
 
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
-
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none

--- a/Tests/Runtime/TestHelper.UI.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.UI.Tests.globalconfig
@@ -6,7 +6,7 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not fot Unity
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
 dotnet_diagnostic.VSTHRD003.severity = none
 
 # IDISP017: Prefer using

--- a/Tests/Runtime/TestHelper.UI.Tests.globalconfig
+++ b/Tests/Runtime/TestHelper.UI.Tests.globalconfig
@@ -6,13 +6,13 @@ dotnet_diagnostic.CS0618.severity = error
 # RS0030: Do not use banned APIs
 dotnet_diagnostic.RS0030.severity = suggestion
 
-# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
-dotnet_diagnostic.VSTHRD003.severity = none
-
 # IDISP017: Prefer using
 # The IDE's suggested fix is a `using var` declaration, which requires C# 8.0; this package
 # supports Unity 2019.4 (C# 7.3), so manual Dispose() calls stay as-is.
 dotnet_diagnostic.IDISP017.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks; Not for Unity
+dotnet_diagnostic.VSTHRD003.severity = none
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none

--- a/Tests/Runtime/Visualizers/DefaultDebugVisualizerTest.cs
+++ b/Tests/Runtime/Visualizers/DefaultDebugVisualizerTest.cs
@@ -43,7 +43,7 @@ namespace TestHelper.UI.Visualizers
 
             // Create reference images and screen points
             _referenceObjects.Clear();
-            var anchoredPositions = new Vector2[]
+            var anchoredPositions = new[]
             {
                 new Vector2(-200, -100),
                 new Vector2(-200, 100),


### PR DESCRIPTION
## Summary

- Enables the Design/Maintainability/Naming/Performance NetAnalyzers categories
  (Runtime, Annotations, Editor) so future rule additions in those categories
  are covered without listing each diagnostic ID individually.
- Resolves the warning-level diagnostics that turned up under the tightened
  config: boxing allocations (RCS1198), redundant async/await (RCS1174), a
  culture-invariant formatting gap (CA1305), CA1052 on TestFixture container
  classes that only nest other fixtures, an unawaited async call in
  UguiTextInputOperatorTest that let assertions race the operation, and
  assorted mechanical cleanup (redundant using/type/default-value
  specifications, unused locals, an unused using directive).
- Suppresses IDISP017 (Prefer using) at the config level across the package:
  the suggested fix is a using var declaration, which requires C# 8.0, but
  this package supports Unity 2019.4 (C# 7.3).

## Test plan

- [x] TestHelper.UI.Tests (PlayMode): 661/661 passed
- [x] TestHelper.UI.Editor.Tests (EditMode): 18/18 passed
- [x] Compilation verified clean after each change