### PR TITLE
Change custom exceptions to inherit from System.Exception instead of ApplicationException

### DIFF
--- a/Runtime/Exceptions/InfiniteLoopException.cs
+++ b/Runtime/Exceptions/InfiniteLoopException.cs
@@ -10,7 +10,7 @@ namespace TestHelper.UI.Exceptions
     /// Detected an infinite loop in monkey testing.
     /// </summary>
     [Serializable]
-    public class InfiniteLoopException : ApplicationException
+    public class InfiniteLoopException : Exception
     {
         public InfiniteLoopException() { }
 

--- a/Runtime/Exceptions/MultipleGameObjectsMatchingException.cs
+++ b/Runtime/Exceptions/MultipleGameObjectsMatchingException.cs
@@ -10,7 +10,7 @@ namespace TestHelper.UI.Exceptions
     /// Detected multiple <c>GameObject</c>s matching the specified criteria.
     /// </summary>
     [Serializable]
-    public class MultipleGameObjectsMatchingException : ApplicationException
+    public class MultipleGameObjectsMatchingException : Exception
     {
         public MultipleGameObjectsMatchingException() { }
 


### PR DESCRIPTION
## Summary
- `ApplicationException` is discouraged by .NET guidelines (Microsoft recommends deriving custom exceptions from `Exception` directly)
- Changes `InfiniteLoopException` and `MultipleGameObjectsMatchingException` to inherit from `System.Exception`

## Test plan
- [x] Existing tests pass