### PR TITLE
Fix NextPageAsync returning true forever when the scroll cannot advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,9 @@ A paginator must implement the following methods:
 - `NextPageAsync` method to navigate to the next page
 - `HasNextPage` property to return whether there is a next page
 
+> [!IMPORTANT]\
+> `NextPageAsync` must eventually return `false`. Callers (e.g., `GameObjectFinder`) loop on the return value, so when the page position cannot advance (e.g., the layout has not been calculated yet), it must return `false` instead of `true`; otherwise the caller loops forever.
+
 In addition, the constructor must meet the following requirements:
 
 - A paginator must have a constructor with one or more parameters

--- a/Runtime/Paginators/IPaginator.cs
+++ b/Runtime/Paginators/IPaginator.cs
@@ -17,6 +17,9 @@ namespace TestHelper.UI.Paginators
     ///     <item>A paginator must have a constructor with one or more parameters</item>
     ///     <item>The first parameter of the constructor is a pageable or scrollable component to be controlled</item>
     ///     <item>The type of the first parameter must be a subclass of <c>MonoBehaviour</c></item>
+    ///     <item><see cref="NextPageAsync"/> must eventually return false: callers loop on the return value, so
+    ///     when the page position cannot advance (e.g., the layout has not been calculated yet), it must return
+    ///     false instead of true</item>
     /// </list>
     /// <seealso cref="TestHelper.UI.Paginators.IPaginatorTest"/>
     /// </remarks>
@@ -35,7 +38,7 @@ namespace TestHelper.UI.Paginators
         /// For scroll components, advance the page by the size of the display area.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>True if page navigation was executed, false if not executed at the end</returns>
+        /// <returns>True if page navigation was executed, false if not executed because the end has been reached or the page position cannot advance</returns>
         UniTask<bool> NextPageAsync(CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/Runtime/Paginators/UguiScrollRectPaginator.cs
+++ b/Runtime/Paginators/UguiScrollRectPaginator.cs
@@ -137,14 +137,19 @@ namespace TestHelper.UI.Paginators
             return viewport?.rect.size ?? Vector2.zero;
         }
 
+        // An axis whose scroll amount is zero (viewport not laid out yet, or content fits in the viewport) is
+        // treated as at the end; judging by normalizedPosition alone would let NextPageAsync return true forever
+        // because the position can never advance.
         private bool IsHorizontalAtEnd()
         {
-            return _scrollRect.normalizedPosition.x >= 1.0f - float.Epsilon;
+            return CalculateHorizontalScrollAmount() <= 0f
+                   || _scrollRect.normalizedPosition.x >= 1.0f - float.Epsilon;
         }
 
         private bool IsVerticalAtEnd()
         {
-            return _scrollRect.normalizedPosition.y <= 0.0f + float.Epsilon;
+            return CalculateVerticalScrollAmount() <= 0f
+                   || _scrollRect.normalizedPosition.y <= 0.0f + float.Epsilon;
         }
 
         private float CalculateHorizontalScrollAmount()

--- a/Runtime/Paginators/UguiScrollRectPaginator.cs
+++ b/Runtime/Paginators/UguiScrollRectPaginator.cs
@@ -109,26 +109,9 @@ namespace TestHelper.UI.Paginators
         /// <inheritdoc />
         public bool HasNextPage()
         {
-            // End determination for bidirectional scrolling
-            if (_scrollRect.horizontal && _scrollRect.vertical)
-            {
-                // Return false only when both horizontal and vertical directions have reached the end
-                return !(IsHorizontalAtEnd() && IsVerticalAtEnd());
-            }
-
-            // For unidirectional scrolling
-            if (_scrollRect.horizontal)
-            {
-                return !IsHorizontalAtEnd();
-            }
-
-            if (_scrollRect.vertical)
-            {
-                return !IsVerticalAtEnd();
-            }
-
-            // When scrolling is disabled
-            return false;
+            // Dispatching by _scrollRect.horizontal/vertical is unnecessary: a disabled axis has a zero scroll
+            // amount, so IsHorizontalAtEnd/IsVerticalAtEnd already report it as at the end.
+            return !(IsHorizontalAtEnd() && IsVerticalAtEnd());
         }
 
         private Vector2 CalculateViewportSize()

--- a/Runtime/Paginators/UguiScrollbarPaginator.cs
+++ b/Runtime/Paginators/UguiScrollbarPaginator.cs
@@ -64,6 +64,13 @@ namespace TestHelper.UI.Paginators
         /// <inheritdoc />
         public bool HasNextPage()
         {
+            // A zero size means the scroll amount is zero (the state before Unity's layout calculation); judging by
+            // value alone would let NextPageAsync return true forever because the value can never advance.
+            if (_scrollbar.size <= 0f)
+            {
+                return false;
+            }
+
             // For Scrollbar, if value is less than 1.0, the next page exists
             return _scrollbar.value < 1.0f - float.Epsilon;
         }

--- a/Runtime/Paginators/UguiScrollbarPaginator.cs
+++ b/Runtime/Paginators/UguiScrollbarPaginator.cs
@@ -64,15 +64,10 @@ namespace TestHelper.UI.Paginators
         /// <inheritdoc />
         public bool HasNextPage()
         {
-            // A zero size means the scroll amount is zero (the state before Unity's layout calculation); judging by
-            // value alone would let NextPageAsync return true forever because the value can never advance.
-            if (_scrollbar.size <= 0f)
-            {
-                return false;
-            }
-
-            // For Scrollbar, if value is less than 1.0, the next page exists
-            return _scrollbar.value < 1.0f - float.Epsilon;
+            // A zero scroll amount (Scrollbar.size is zero before Unity's layout calculation) is also "no next
+            // page"; judging by value alone would let NextPageAsync return true forever because the value can
+            // never advance.
+            return CalculateNormalizedScrollAmount() > 0f && _scrollbar.value < 1.0f - float.Epsilon;
         }
 
         private float CalculateNormalizedScrollAmount()

--- a/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
@@ -207,7 +207,8 @@ namespace TestHelper.UI.Paginators
         [Category("Acceptance")]
         public async Task NextPageAsync_ViewportSizeIsZero_ReturnsFalse(bool horizontal, bool vertical)
         {
-            var scrollRect = CreateScrollRectWithZeroSizeViewport();
+            // A zero-size viewport reproduces the state before Unity's layout calculation.
+            var scrollRect = CreateScrollRect(Vector2.zero, new Vector2(500f, 500f));
             scrollRect.horizontal = horizontal;
             scrollRect.vertical = vertical;
             var sut = new UguiScrollRectPaginator(scrollRect);
@@ -219,16 +220,81 @@ namespace TestHelper.UI.Paginators
             Assert.That(scrollRect.normalizedPosition, Is.EqualTo(beforePosition), "normalizedPosition");
         }
 
-        private static ScrollRect CreateScrollRectWithZeroSizeViewport()
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(true, true)]
+        [CreateScene]
+        public async Task NextPageAsync_ContentFitsViewport_ReturnsFalse(bool horizontal, bool vertical)
         {
-            // Reproduces the state before Unity's layout calculation, where the viewport rect is still zero-size.
+            var scrollRect = CreateScrollRect(new Vector2(100f, 100f), new Vector2(50f, 50f));
+            scrollRect.horizontal = horizontal;
+            scrollRect.vertical = vertical;
+            var sut = new UguiScrollRectPaginator(scrollRect);
+            var beforePosition = scrollRect.normalizedPosition;
+
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.False, "return value");
+            Assert.That(scrollRect.normalizedPosition, Is.EqualTo(beforePosition), "normalizedPosition");
+        }
+
+        [Test]
+        [CreateScene]
+        public async Task NextPageAsync_BothScrollHorizontalContentFitsViewport_ScrollsVerticallyAndReturnsTrue()
+        {
+            var scrollRect = CreateScrollRect(new Vector2(100f, 100f), new Vector2(50f, 500f));
+            var sut = new UguiScrollRectPaginator(scrollRect);
+            var beforePosition = scrollRect.normalizedPosition;
+
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.True, "return value");
+            Assert.That(scrollRect.normalizedPosition.x, Is.EqualTo(beforePosition.x), "normalizedPosition.x");
+            Assert.That(scrollRect.normalizedPosition.y, Is.LessThan(beforePosition.y), "normalizedPosition.y");
+        }
+
+        [Test]
+        [CreateScene]
+        public async Task NextPageAsync_BothScrollHorizontalAtEndAndVerticalContentFitsViewport_ReturnsFalse()
+        {
+            var scrollRect = CreateScrollRect(new Vector2(100f, 100f), new Vector2(500f, 50f));
+            // Shift content down so that verticalNormalizedPosition reads 1 (not at end) although the axis cannot advance.
+            scrollRect.content.anchoredPosition = new Vector2(0f, -100f);
+            scrollRect.horizontalNormalizedPosition = 1f;
+            Assume.That(scrollRect.verticalNormalizedPosition, Is.EqualTo(1f));
+            var sut = new UguiScrollRectPaginator(scrollRect);
+            var beforePosition = scrollRect.normalizedPosition;
+
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.False, "return value");
+            Assert.That(scrollRect.normalizedPosition, Is.EqualTo(beforePosition), "normalizedPosition");
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        public async Task NextPageAsync_AfterResetAsyncFollowingPaginationEnd_ScrollsAndReturnsTrue()
+        {
+            var scrollRect = _horizontalScrollView.GetComponent<ScrollRect>();
+            scrollRect.normalizedPosition = new Vector2(1f, 0f);
+            var sut = new UguiScrollRectPaginator(scrollRect);
+            Assume.That(await sut.NextPageAsync(), Is.False);
+
+            await sut.ResetAsync();
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.True, "return value");
+            Assert.That(scrollRect.normalizedPosition.x, Is.GreaterThan(0f), "normalizedPosition.x");
+        }
+
+        private static ScrollRect CreateScrollRect(Vector2 viewportSize, Vector2 contentSize)
+        {
             var scrollRect = new GameObject("Scroll View", typeof(RectTransform)).AddComponent<ScrollRect>();
-            ((RectTransform)scrollRect.transform).sizeDelta = Vector2.zero;
+            ((RectTransform)scrollRect.transform).sizeDelta = viewportSize;
             var content = new GameObject("Content", typeof(RectTransform)).GetComponent<RectTransform>();
             content.SetParent(scrollRect.transform, false);
-            content.sizeDelta = new Vector2(500f, 500f);
+            content.sizeDelta = contentSize;
             scrollRect.content = content;
-            Assume.That(((RectTransform)scrollRect.transform).rect.size, Is.EqualTo(Vector2.zero));
             return scrollRect;
         }
 

--- a/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
@@ -273,18 +273,20 @@ namespace TestHelper.UI.Paginators
 
         [Test]
         [LoadScene(TestScene)]
-        public async Task NextPageAsync_AfterResetAsyncFollowingPaginationEnd_ScrollsAndReturnsTrue()
+        public async Task NextPageAsync_AfterResetAsyncFollowingHorizontalEnd_ScrollsHorizontallyAndReturnsTrue()
         {
-            var scrollRect = _horizontalScrollView.GetComponent<ScrollRect>();
-            scrollRect.normalizedPosition = new Vector2(1f, 0f);
+            var scrollRect = _bothScrollView.GetComponent<ScrollRect>();
+            scrollRect.normalizedPosition = new Vector2(0.99f, 1f);
             var sut = new UguiScrollRectPaginator(scrollRect);
-            Assume.That(await sut.NextPageAsync(), Is.False);
+            Assume.That(await sut.NextPageAsync(), Is.True);
+            Assume.That(scrollRect.normalizedPosition.x, Is.EqualTo(1f).Within(float.Epsilon));
 
             await sut.ResetAsync();
             var actual = await sut.NextPageAsync();
 
             Assert.That(actual, Is.True, "return value");
             Assert.That(scrollRect.normalizedPosition.x, Is.GreaterThan(0f), "normalizedPosition.x");
+            Assert.That(scrollRect.normalizedPosition.y, Is.EqualTo(1f), "normalizedPosition.y");
         }
 
         private static ScrollRect CreateScrollRect(Vector2 viewportSize, Vector2 contentSize)

--- a/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollRectPaginatorTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Threading.Tasks;
@@ -198,6 +198,38 @@ namespace TestHelper.UI.Paginators
 
             Assert.That(actual, Is.False);
             Assert.That(scrollRect.normalizedPosition, Is.EqualTo(new Vector2(0f, 1f)));
+        }
+
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(true, true)]
+        [CreateScene]
+        [Category("Acceptance")]
+        public async Task NextPageAsync_ViewportSizeIsZero_ReturnsFalse(bool horizontal, bool vertical)
+        {
+            var scrollRect = CreateScrollRectWithZeroSizeViewport();
+            scrollRect.horizontal = horizontal;
+            scrollRect.vertical = vertical;
+            var sut = new UguiScrollRectPaginator(scrollRect);
+            var beforePosition = scrollRect.normalizedPosition;
+
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.False, "return value");
+            Assert.That(scrollRect.normalizedPosition, Is.EqualTo(beforePosition), "normalizedPosition");
+        }
+
+        private static ScrollRect CreateScrollRectWithZeroSizeViewport()
+        {
+            // Reproduces the state before Unity's layout calculation, where the viewport rect is still zero-size.
+            var scrollRect = new GameObject("Scroll View", typeof(RectTransform)).AddComponent<ScrollRect>();
+            ((RectTransform)scrollRect.transform).sizeDelta = Vector2.zero;
+            var content = new GameObject("Content", typeof(RectTransform)).GetComponent<RectTransform>();
+            content.SetParent(scrollRect.transform, false);
+            content.sizeDelta = new Vector2(500f, 500f);
+            scrollRect.content = content;
+            Assume.That(((RectTransform)scrollRect.transform).rect.size, Is.EqualTo(Vector2.zero));
+            return scrollRect;
         }
 
         [TestCase(0f)]

--- a/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
@@ -136,36 +136,29 @@ namespace TestHelper.UI.Paginators
         }
 
         [Test]
-        [LoadScene(TestScene)]
+        [CreateScene]
         [Category("Acceptance")]
         public async Task NextPageAsync_ScrollbarSizeIsZero_ReturnsFalse()
         {
-            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
-            // A zero size reproduces the state before Unity's layout calculation.
-            scrollbar.size = 0f;
-            scrollbar.value = 0f;
-            await Task.Yield();
-
+            // A zero size reproduces the state before Unity's layout calculation. A script-created Scrollbar is
+            // used because a scene Scrollbar is driven by its ScrollRect, which rewrites the size every frame.
+            var scrollbar = CreateScrollbar(size: 0f, value: 0f);
             var sut = new UguiScrollbarPaginator(scrollbar);
-            var beforeValue = scrollbar.value;
 
             var actual = await sut.NextPageAsync();
 
             Assert.That(actual, Is.False, "return value");
-            Assert.That(scrollbar.value, Is.EqualTo(beforeValue), "value");
+            Assert.That(scrollbar.value, Is.EqualTo(0f), "value");
         }
 
         [Test]
-        [LoadScene(TestScene)]
+        [CreateScene]
         [Category("Acceptance")]
         public async Task NextPageAsync_ScrollbarSizeIsOne_ValueBecomesOneAndReturnsTrue()
         {
-            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
-            scrollbar.size = 1f;
-            scrollbar.value = 0f;
-            await Task.Yield();
-
+            var scrollbar = CreateScrollbar(size: 1f, value: 0f);
             var sut = new UguiScrollbarPaginator(scrollbar);
+
             var actual = await sut.NextPageAsync();
 
             Assert.That(actual, Is.True, "return value");
@@ -174,18 +167,23 @@ namespace TestHelper.UI.Paginators
 
         [TestCase(0f)]
         [TestCase(0.5f)]
-        [LoadScene(TestScene)]
-        public async Task HasNextPage_ScrollbarSizeIsZero_ReturnsFalse(float value)
+        [CreateScene]
+        public void HasNextPage_ScrollbarSizeIsZero_ReturnsFalse(float value)
         {
-            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
-            scrollbar.size = 0f;
-            scrollbar.value = value;
-            await Task.Yield();
-
+            var scrollbar = CreateScrollbar(size: 0f, value: value);
             var sut = new UguiScrollbarPaginator(scrollbar);
+
             var actual = sut.HasNextPage();
 
             Assert.That(actual, Is.False);
+        }
+
+        private static Scrollbar CreateScrollbar(float size, float value)
+        {
+            var scrollbar = new GameObject("Scrollbar", typeof(RectTransform)).AddComponent<Scrollbar>();
+            scrollbar.size = size;
+            scrollbar.value = value;
+            return scrollbar;
         }
 
         [TestCase(0f)]

--- a/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
@@ -155,6 +155,39 @@ namespace TestHelper.UI.Paginators
             Assert.That(scrollbar.value, Is.EqualTo(beforeValue), "value");
         }
 
+        [Test]
+        [LoadScene(TestScene)]
+        [Category("Acceptance")]
+        public async Task NextPageAsync_ScrollbarSizeIsOne_ValueBecomesOneAndReturnsTrue()
+        {
+            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
+            scrollbar.size = 1f;
+            scrollbar.value = 0f;
+            await Task.Yield();
+
+            var sut = new UguiScrollbarPaginator(scrollbar);
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.True, "return value");
+            Assert.That(scrollbar.value, Is.EqualTo(1f), "value");
+        }
+
+        [TestCase(0f)]
+        [TestCase(0.5f)]
+        [LoadScene(TestScene)]
+        public async Task HasNextPage_ScrollbarSizeIsZero_ReturnsFalse(float value)
+        {
+            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
+            scrollbar.size = 0f;
+            scrollbar.value = value;
+            await Task.Yield();
+
+            var sut = new UguiScrollbarPaginator(scrollbar);
+            var actual = sut.HasNextPage();
+
+            Assert.That(actual, Is.False);
+        }
+
         [TestCase(0f)]
         [TestCase(0.5f)]
         [LoadScene(TestScene)]

--- a/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/UguiScrollbarPaginatorTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Threading.Tasks;
@@ -133,6 +133,26 @@ namespace TestHelper.UI.Paginators
 
             // Value increase should be based on scrollbar.size
             Assert.That(scrollbar.value, Is.EqualTo(scrollbar.size).Within(0.05f));
+        }
+
+        [Test]
+        [LoadScene(TestScene)]
+        [Category("Acceptance")]
+        public async Task NextPageAsync_ScrollbarSizeIsZero_ReturnsFalse()
+        {
+            var scrollbar = _horizontalScrollbar.GetComponent<Scrollbar>();
+            // A zero size reproduces the state before Unity's layout calculation.
+            scrollbar.size = 0f;
+            scrollbar.value = 0f;
+            await Task.Yield();
+
+            var sut = new UguiScrollbarPaginator(scrollbar);
+            var beforeValue = scrollbar.value;
+
+            var actual = await sut.NextPageAsync();
+
+            Assert.That(actual, Is.False, "return value");
+            Assert.That(scrollbar.value, Is.EqualTo(beforeValue), "value");
         }
 
         [TestCase(0f)]


### PR DESCRIPTION
## Problem

`NextPageAsync()` can keep returning `true` forever when the scroll position cannot advance, so callers looping `while (await paginator.NextPageAsync())` (e.g., `GameObjectFinder` searching for a node that does not exist yet) never terminate.

- **`UguiScrollRectPaginator`**: when the viewport rect is still zero-size (before Unity's layout calculation) or the content fits in the viewport, the calculated scroll amount is 0, `normalizedPosition` never moves, and `HasNextPage()` stays `true`. The bidirectional mode could also cycle forever (x resets to 0 repeatedly while the vertical axis cannot advance).
- **`UguiScrollbarPaginator`**: when `Scrollbar.size` is 0 (before layout calculation), the scroll amount equals the size, so `value` never advances and `HasNextPage()` stays `true`.

## Fix

Treat an axis whose scroll amount is zero as having no next page:

- `UguiScrollRectPaginator`: `IsHorizontalAtEnd()` / `IsVerticalAtEnd()` also return `true` when the axis's scroll amount is 0. `HasNextPage()` collapses to `!(IsHorizontalAtEnd() && IsVerticalAtEnd())` since a disabled axis also has a zero amount.
- `UguiScrollbarPaginator`: `HasNextPage()` returns `false` when `CalculateNormalizedScrollAmount()` is 0.

## Documentation

The "must eventually return false" contract of `NextPageAsync` is stated in neither the `IPaginator` XML doc nor the README, so third-party implementers could ship the same defect. Added it to both (`6678bfb`).

## Tests

Test-first: each reproduction test was committed failing before its fix (`28d4730`, `3864df4`).

- Reproduction: zero-size viewport (h/v/both), `Scrollbar.size == 0`
- Regression: content fits viewport (h/v/both), bidirectional with one non-advanceable axis, `ResetAsync` clearing the horizontal-end latch, `Scrollbar.size == 1` still terminating in one call
- All 52 paginator tests and the full `TestHelper.UI.Tests` assembly (665) pass

## Follow-ups (not in this PR)

- `GameObjectFinder.FindInPaginatorAsync` loops `while (nextPage)` without re-checking `timeoutSeconds`, so a non-terminating third-party paginator still hangs instead of throwing `TimeoutException`
- `Scrollbar.numberOfSteps > 1` can quantize `value` in the getter so `value + size` reads back unchanged — the same loop via a different door; a progress-based guard in `NextPageAsync` would subsume it

🤖 Generated with [Claude Code](https://claude.com/claude-code)