### PR TITLE
Performance improvements for GameObjectFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Constructor arguments:
 - **reachableStrategy**: Strategy to examine whether `GameObject` is reachable from the user. The default implementation returns true if it can raycast from `Camera.main` to the pivot position.
 - **isInteractable**: Function returns whether the `Component` is interactable or not. The default implementation returns true if the component is a uGUI compatible component and its `interactable` property is true.
 
+> [!WARNING]\
+> A `GameObjectFinder` instance reuses internal buffers across find calls for performance. Running multiple finds concurrently on the same instance corrupts their results; use a separate instance per concurrent find.
+
 
 #### Find GameObject by name
 

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ The custom matcher can be specified as an argument to the `GameObjectFinder.Find
 
 A matcher must implement the following members:
 
-- `ComponentType` property to return the component type that `GameObjectFinder` uses to collect candidate `GameObjects` before evaluating `IsMatch`. Return `typeof(Transform)` if the matcher has no component criterion
+- `ComponentType` property to return the component type that `GameObjectFinder` uses to collect candidate `GameObjects` before evaluating `IsMatch`. Return `typeof(Transform)` if the matcher has no component criterion. An interface or other non-`Component` type is also allowed; `GameObjectFinder` then falls back to `typeof(Transform)` for candidate collection and `IsMatch` does the filtering
 - `IsMatch` method to determine whether the specified `GameObject` matches the criteria
 
 For example, the built-in `ButtonMatcher` class's `IsMatch` method returns `true` for `GameObjects` that match the specified button element `name`, `path`, `text`, and `texture`.

--- a/README.md
+++ b/README.md
@@ -561,6 +561,11 @@ The `DefaultReachableStrategy` constructor accepts optional parameters:
 If your game title uses a custom UI framework that is not uGUI compatible and/or requires custom conditions for searching, you can implement the `IGameObjectMatcher` interface.
 The custom matcher can be specified as an argument to the `GameObjectFinder.FindByMatcherAsync` method.
 
+A matcher must implement the following members:
+
+- `ComponentType` property to return the component type that `GameObjectFinder` uses to collect candidate `GameObjects` before evaluating `IsMatch`. Return `typeof(Transform)` if the matcher has no component criterion
+- `IsMatch` method to determine whether the specified `GameObject` matches the criteria
+
 For example, the built-in `ButtonMatcher` class's `IsMatch` method returns `true` for `GameObjects` that match the specified button element `name`, `path`, `text`, and `texture`.
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ public class MyIntegrationTest
 }
 ```
 
+> [!TIP]\
+> When you can identify the component type, using `FindByMatcherAsync` is more advantageous in both execution speed and memory usage.
+
 
 #### Find GameObject by path
 
@@ -86,6 +89,9 @@ public class MyIntegrationTest
     }
 }
 ```
+
+> [!TIP]\
+> When you can identify the component type, using `FindByMatcherAsync` is more advantageous in both execution speed and memory usage.
 
 
 #### Find GameObject by matcher
@@ -125,6 +131,9 @@ public class MyIntegrationTest
     }
 }
 ```
+
+> [!TIP]\
+> A matcher that can specify a component type is more advantageous in both execution speed and memory usage than a matcher based only on `name` or `path`.
 
 
 #### Find GameObject in pageable component

--- a/Runtime/Extensions/ObjectExtensions.cs
+++ b/Runtime/Extensions/ObjectExtensions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace TestHelper.UI.Extensions
 {
     /// <summary>
-    /// Extension methods for <see cref="UnityEngine.Object"/>.
+    /// Extension methods and version-bridging helpers for <see cref="UnityEngine.Object"/>.
     /// </summary>
     internal static class ObjectExtensions
     {
@@ -22,5 +24,41 @@ namespace TestHelper.UI.Extensions
 #else
         internal static int GetId(this Object self) => self.GetInstanceID();
 #endif
+
+        /// <summary>
+        /// Finds all loaded objects of the specified type, excluding objects on inactive <c>GameObject</c>s.
+        /// Result order is unspecified; on Unity 6.4 or newer the find APIs cannot sort at all.
+        /// </summary>
+        /// <param name="type">Type to find; must derive from <see cref="UnityEngine.Object"/></param>
+        /// <returns>Found objects</returns>
+        internal static Object[] FindObjectsByType(Type type)
+        {
+#if UNITY_6000_4_OR_NEWER
+            return Object.FindObjectsByType(type, FindObjectsInactive.Exclude);
+#elif UNITY_2022_3_OR_NEWER
+            return Object.FindObjectsByType(type, FindObjectsSortMode.None);
+            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
+#else
+            return Object.FindObjectsOfType(type);
+#endif
+        }
+
+        /// <summary>
+        /// Finds all loaded objects of the specified type, excluding objects on inactive <c>GameObject</c>s.
+        /// Result order is unspecified; on Unity 6.4 or newer the find APIs cannot sort at all.
+        /// </summary>
+        /// <typeparam name="T">Type to find</typeparam>
+        /// <returns>Found objects</returns>
+        internal static T[] FindObjectsByType<T>() where T : Object
+        {
+#if UNITY_6000_4_OR_NEWER
+            return Object.FindObjectsByType<T>(FindObjectsInactive.Exclude);
+#elif UNITY_2022_3_OR_NEWER
+            return Object.FindObjectsByType<T>(FindObjectsSortMode.None);
+            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
+#else
+            return Object.FindObjectsOfType<T>();
+#endif
+        }
     }
 }

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -281,6 +281,9 @@ namespace TestHelper.UI
         /// <summary>
         /// Find <c>GameObject</c> by name (wait until they appear).
         /// </summary>
+        /// <remarks>
+        /// When you can identify the component type, using <see cref="FindByMatcherAsync"/> is more advantageous in both execution speed and memory usage.
+        /// </remarks>
         /// <param name="name">Find <c>GameObject</c> name</param>
         /// <param name="reachable">Find only reachable object</param>
         /// <param name="interactable">Find only interactable object</param>
@@ -301,6 +304,9 @@ namespace TestHelper.UI
         /// <summary>
         /// Find <c>GameObject</c> by path (wait until they appear).
         /// </summary>
+        /// <remarks>
+        /// When you can identify the component type, using <see cref="FindByMatcherAsync"/> is more advantageous in both execution speed and memory usage.
+        /// </remarks>
         /// <param name="path">Find <c>GameObject</c> hierarchy path separated by `/`. Can specify wildcards of glob pattern (`?`, `*`, and `**`).</param>
         /// <param name="reachable">Find only reachable object</param>
         /// <param name="interactable">Find only interactable object</param>

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -117,12 +117,14 @@ namespace TestHelper.UI
         private static List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher)
         {
             var componentType = matcher.ComponentType;
-            if (componentType == typeof(Component) || !typeof(Component).IsAssignableFrom(componentType))
+            if (componentType == null || componentType == typeof(Component) ||
+                !typeof(Component).IsAssignableFrom(componentType))
             {
                 // Transform yields exactly one hit per GameObject, so remap types the native query
-                // handles poorly: typeof(Component) returns every component instance in the scene,
-                // and FindObjectsByType rejects non-Object-derived types (e.g., interfaces).
-                // matcher.IsMatch still applies the matcher's own criteria either way.
+                // handles poorly: null (a custom matcher without a hint), typeof(Component) (returns
+                // every component instance in the scene), and non-Object-derived types such as
+                // interfaces (rejected by FindObjectsByType). matcher.IsMatch still applies the
+                // matcher's own criteria either way.
                 componentType = typeof(Transform);
             }
 

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -27,6 +27,14 @@ namespace TestHelper.UI
         private readonly Func<Component, bool> _isInteractable;
         private readonly IVisualizer _visualizer;
 
+        // Reused across find calls to avoid reallocating per poll; not safe for concurrent
+        // finds on the same instance.
+        private readonly HashSet<GameObject> _seenObjects = new HashSet<GameObject>();
+        private readonly List<GameObject> _foundObjects = new List<GameObject>();
+
+        private readonly Dictionary<GameObject, RaycastResult> _raycastResults =
+            new Dictionary<GameObject, RaycastResult>();
+
         private const double MinTimeoutSeconds = 0.01d;
         private const double MaxPollingIntervalSeconds = 1.0d;
 
@@ -65,9 +73,8 @@ namespace TestHelper.UI
         }
 
         private bool FilterToOnlyReachable(ref List<GameObject> objects,
-            out Dictionary<GameObject, RaycastResult> raycastResults)
+            Dictionary<GameObject, RaycastResult> raycastResults)
         {
-            raycastResults = new Dictionary<GameObject, RaycastResult>(objects.Count);
             for (var i = objects.Count - 1; i >= 0; i--)
             {
                 var current = objects[i];
@@ -114,7 +121,7 @@ namespace TestHelper.UI
             return false;
         }
 
-        private static List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher)
+        private List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher)
         {
             var componentType = matcher.ComponentType;
             if (componentType == null || componentType == typeof(Component) ||
@@ -133,18 +140,18 @@ namespace TestHelper.UI
             // Dedupe by GameObject: FindObjectsByType returns one hit per component instance,
             // so a GameObject holding multiple matching components would otherwise be judged
             // as multiple matches.
-            var seenObjects = new HashSet<GameObject>();
-            var foundObjects = new List<GameObject>();
+            _seenObjects.Clear();
+            _foundObjects.Clear();
             foreach (var component in components)
             {
                 var gameObject = ((Component)component).gameObject;
-                if (seenObjects.Add(gameObject) && matcher.IsMatch(gameObject))
+                if (_seenObjects.Add(gameObject) && matcher.IsMatch(gameObject))
                 {
-                    foundObjects.Add(gameObject);
+                    _foundObjects.Add(gameObject);
                 }
             }
 
-            return foundObjects;
+            return _foundObjects;
         }
 
         private (GameObject, RaycastResult, Reason) FindByMatcher(IGameObjectMatcher matcher,
@@ -156,10 +163,13 @@ namespace TestHelper.UI
                 return (null, default, Reason.NotFound);
             }
 
-            Dictionary<GameObject, RaycastResult> raycastResults = null;
-            if (reachable && !FilterToOnlyReachable(ref foundObjects, out raycastResults))
+            if (reachable)
             {
-                return (null, default, Reason.NotReachable);
+                _raycastResults.Clear();
+                if (!FilterToOnlyReachable(ref foundObjects, _raycastResults))
+                {
+                    return (null, default, Reason.NotReachable);
+                }
             }
 
             if (interactable && !FilterToOnlyInteractable(ref foundObjects))
@@ -174,8 +184,10 @@ namespace TestHelper.UI
 
             // Reuse the raycast captured while filtering; raycasting the survivor again would
             // repeat the most expensive step of the poll for an identical same-frame result.
+            // RaycastResult is a struct, so this indexer read copies out of _raycastResults;
+            // the caller's value survives the field being Cleared on the next find.
             var resultObject = foundObjects[0];
-            var raycastResult = reachable ? raycastResults[resultObject] : new RaycastResult();
+            var raycastResult = reachable ? _raycastResults[resultObject] : new RaycastResult();
             return (resultObject, raycastResult, Reason.None);
         }
 

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -7,13 +7,13 @@ using System.Globalization;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using TestHelper.UI.Exceptions;
+using TestHelper.UI.Extensions;
 using TestHelper.UI.GameObjectMatchers;
 using TestHelper.UI.Paginators;
 using TestHelper.UI.Strategies;
 using TestHelper.UI.Visualizers;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using Object = UnityEngine.Object;
 
 namespace TestHelper.UI
 {
@@ -114,21 +114,16 @@ namespace TestHelper.UI
         private static List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher)
         {
             var componentType = matcher.ComponentType;
-            if (!typeof(Component).IsAssignableFrom(componentType))
+            if (componentType == typeof(Component) || !typeof(Component).IsAssignableFrom(componentType))
             {
-                // FindObjectsByType rejects non-Object-derived types (e.g., interfaces),
-                // while matcher.IsMatch can still filter by them via TryGetComponent.
+                // Transform yields exactly one hit per GameObject, so remap types the native query
+                // handles poorly: typeof(Component) returns every component instance in the scene,
+                // and FindObjectsByType rejects non-Object-derived types (e.g., interfaces).
+                // matcher.IsMatch still applies the matcher's own criteria either way.
                 componentType = typeof(Transform);
             }
 
-#if UNITY_6000_4_OR_NEWER
-            var components = Object.FindObjectsByType(componentType, FindObjectsInactive.Exclude);
-#elif UNITY_2022_3_OR_NEWER
-            var components = Object.FindObjectsByType(componentType, FindObjectsSortMode.None);
-            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
-#else
-            var components = Object.FindObjectsOfType(componentType);
-#endif
+            var components = ObjectExtensions.FindObjectsByType(componentType);
 
             // Dedupe by GameObject: FindObjectsByType returns one hit per component instance,
             // so a GameObject holding multiple matching components would otherwise be judged
@@ -195,7 +190,12 @@ namespace TestHelper.UI
 
             while (nextPage)
             {
+                // FindByMatcher is a synchronous scene snapshot, not a blocking variant of
+                // FindByMatcherAsync; awaiting the async method here would recurse into the
+                // polling wrapper that calls this method.
+#pragma warning disable VSTHRD103
                 var (foundObject, raycastResult, reason) = FindByMatcher(matcher, reachable, interactable);
+#pragma warning restore VSTHRD103
 
                 if (foundObject != null)
                 {

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -13,7 +13,6 @@ using TestHelper.UI.Strategies;
 using TestHelper.UI.Visualizers;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
 namespace TestHelper.UI
@@ -23,8 +22,6 @@ namespace TestHelper.UI
     /// </summary>
     public class GameObjectFinder
     {
-        private static Scene s_dontDestroyOnLoadScene;
-
         private readonly double _timeoutSeconds;
         private readonly IReachableStrategy _reachableStrategy;
         private readonly Func<Component, bool> _isInteractable;
@@ -56,56 +53,6 @@ namespace TestHelper.UI
             _reachableStrategy = reachableStrategy ?? new DefaultReachableStrategy();
             _isInteractable = isInteractable ?? DefaultComponentInteractableStrategy.IsInteractable;
             _visualizer = visualizer;
-        }
-
-        private static Scene GetDontDestroyOnLoadScene()
-        {
-            if (s_dontDestroyOnLoadScene.IsValid())
-            {
-                return s_dontDestroyOnLoadScene;
-            }
-
-            var gameObject = new GameObject("DontDestroyOnLoad Object, Created by GameObjectFinder");
-            Object.DontDestroyOnLoad(gameObject);
-            s_dontDestroyOnLoadScene = gameObject.scene;
-
-            return s_dontDestroyOnLoadScene;
-        }
-
-        private static List<Scene> GetAllScenes()
-        {
-            var scenes = new List<Scene> { GetDontDestroyOnLoadScene() };
-            for (var i = 0; i < SceneManager.sceneCount; i++)
-            {
-                var scene = SceneManager.GetSceneAt(i);
-                if (scene.isLoaded)
-                {
-                    scenes.Add(scene);
-                }
-            }
-
-            return scenes;
-        }
-
-        private static IEnumerable<GameObject> FindGameObjectRecursive(GameObject current, IGameObjectMatcher matcher)
-        {
-            if (!current.activeInHierarchy)
-            {
-                yield break;
-            }
-
-            if (matcher.IsMatch(current))
-            {
-                yield return current;
-            }
-
-            foreach (Transform childTransform in current.transform)
-            {
-                foreach (var found in FindGameObjectRecursive(childTransform.gameObject, matcher))
-                {
-                    yield return found;
-                }
-            }
         }
 
         private enum Reason
@@ -164,21 +111,36 @@ namespace TestHelper.UI
             return false;
         }
 
-        private static List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher, Scene scene)
+        private static List<GameObject> FindAllByMatcher(IGameObjectMatcher matcher)
         {
-            var scenes = scene != default ? new List<Scene> { scene } : GetAllScenes();
-            var foundObjects = new List<GameObject>();
-            var rootGameObjects = new List<GameObject>();
-            foreach (var loadedScene in scenes)
+            var componentType = matcher.ComponentType;
+            if (!typeof(Component).IsAssignableFrom(componentType))
             {
-                // Do not rely on GetRootGameObjects clearing the buffer. It does not on Unity 6000.5,
-                // so a reused buffer keeps the previous scenes' roots and walks them again. With three
-                // or more scenes loaded, that makes a single GameObject match more than once.
-                rootGameObjects.Clear();
-                loadedScene.GetRootGameObjects(rootGameObjects);
-                foreach (var rootGameObject in rootGameObjects)
+                // FindObjectsByType rejects non-Object-derived types (e.g., interfaces),
+                // while matcher.IsMatch can still filter by them via TryGetComponent.
+                componentType = typeof(Transform);
+            }
+
+#if UNITY_6000_4_OR_NEWER
+            var components = Object.FindObjectsByType(componentType, FindObjectsInactive.Exclude);
+#elif UNITY_2022_3_OR_NEWER
+            var components = Object.FindObjectsByType(componentType, FindObjectsSortMode.None);
+            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
+#else
+            var components = Object.FindObjectsOfType(componentType);
+#endif
+
+            // Dedupe by GameObject: FindObjectsByType returns one hit per component instance,
+            // so a GameObject holding multiple matching components would otherwise be judged
+            // as multiple matches.
+            var seenObjects = new HashSet<GameObject>();
+            var foundObjects = new List<GameObject>();
+            foreach (var component in components)
+            {
+                var gameObject = ((Component)component).gameObject;
+                if (seenObjects.Add(gameObject) && matcher.IsMatch(gameObject))
                 {
-                    foundObjects.AddRange(FindGameObjectRecursive(rootGameObject, matcher));
+                    foundObjects.Add(gameObject);
                 }
             }
 
@@ -186,9 +148,9 @@ namespace TestHelper.UI
         }
 
         private (GameObject, RaycastResult, Reason) FindByMatcher(IGameObjectMatcher matcher,
-            bool reachable, bool interactable, Scene scene = default)
+            bool reachable, bool interactable)
         {
-            var foundObjects = FindAllByMatcher(matcher, scene);
+            var foundObjects = FindAllByMatcher(matcher);
             if (foundObjects.Count == 0)
             {
                 return (null, default, Reason.NotFound);

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -64,13 +64,16 @@ namespace TestHelper.UI
             None
         }
 
-        private bool FilterToOnlyReachable(ref List<GameObject> objects)
+        private bool FilterToOnlyReachable(ref List<GameObject> objects,
+            out Dictionary<GameObject, RaycastResult> raycastResults)
         {
+            raycastResults = new Dictionary<GameObject, RaycastResult>(objects.Count);
             for (var i = objects.Count - 1; i >= 0; i--)
             {
                 var current = objects[i];
                 if (_reachableStrategy.IsReachable(current, out var raycastResult))
                 {
+                    raycastResults.Add(current, raycastResult);
                     continue;
                 }
 
@@ -151,7 +154,8 @@ namespace TestHelper.UI
                 return (null, default, Reason.NotFound);
             }
 
-            if (reachable && !FilterToOnlyReachable(ref foundObjects))
+            Dictionary<GameObject, RaycastResult> raycastResults = null;
+            if (reachable && !FilterToOnlyReachable(ref foundObjects, out raycastResults))
             {
                 return (null, default, Reason.NotReachable);
             }
@@ -166,13 +170,10 @@ namespace TestHelper.UI
                 return (null, default, Reason.MultipleMatching);
             }
 
+            // Reuse the raycast captured while filtering; raycasting the survivor again would
+            // repeat the most expensive step of the poll for an identical same-frame result.
             var resultObject = foundObjects[0];
-            if (!reachable)
-            {
-                return (resultObject, new RaycastResult(), Reason.None);
-            }
-
-            _reachableStrategy.IsReachable(resultObject, out var raycastResult);
+            var raycastResult = reachable ? raycastResults[resultObject] : new RaycastResult();
             return (resultObject, raycastResult, Reason.None);
         }
 

--- a/Runtime/GameObjectFinder.cs
+++ b/Runtime/GameObjectFinder.cs
@@ -20,6 +20,11 @@ namespace TestHelper.UI
     /// <summary>
     /// Find <c>GameObject</c> by name or path (glob). Wait until they appear.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="GameObjectFinder"/> instance reuses internal buffers across find calls for performance.
+    /// Running multiple finds concurrently on the same instance corrupts their results; use a separate instance
+    /// per concurrent find.
+    /// </remarks>
     public class GameObjectFinder
     {
         private readonly double _timeoutSeconds;

--- a/Runtime/GameObjectMatchers/ButtonMatcher.cs
+++ b/Runtime/GameObjectMatchers/ButtonMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/ButtonMatcher.cs
+++ b/Runtime/GameObjectMatchers/ButtonMatcher.cs
@@ -27,6 +27,9 @@ namespace TestHelper.UI.GameObjectMatchers
         private readonly string _text;
         private readonly string _texture;
 
+        /// <inheritdoc/>
+        public Type ComponentType => null;
+
         /// <summary>
         /// Constructor with properties of <c>Button</c>.
         /// </summary>

--- a/Runtime/GameObjectMatchers/ButtonMatcher.cs
+++ b/Runtime/GameObjectMatchers/ButtonMatcher.cs
@@ -21,14 +21,13 @@ namespace TestHelper.UI.GameObjectMatchers
     /// </remarks>
     public class ButtonMatcher : IGameObjectMatcher
     {
-        private readonly Type _componentType;
         private readonly string _name;
         private readonly string _path;
         private readonly string _text;
         private readonly string _texture;
 
         /// <inheritdoc/>
-        public Type ComponentType => null;
+        public Type ComponentType { get; }
 
         /// <summary>
         /// Constructor with properties of <c>Button</c>.
@@ -42,7 +41,7 @@ namespace TestHelper.UI.GameObjectMatchers
         public ButtonMatcher(Type componentType = null, string name = null, string path = null, string text = null,
             string texture = null)
         {
-            _componentType = componentType ?? typeof(Button);
+            ComponentType = componentType ?? typeof(Button);
             _name = name;
             _path = path;
             _text = text;
@@ -52,7 +51,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public override string ToString()
         {
-            var builder = new StringBuilder($"type={_componentType}");
+            var builder = new StringBuilder($"type={ComponentType}");
             if (_name != null)
             {
                 builder.Append($", name={_name}");
@@ -79,7 +78,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public bool IsMatch(GameObject gameObject)
         {
-            if (!gameObject.TryGetComponent(_componentType, out _))
+            if (!gameObject.TryGetComponent(ComponentType, out _))
             {
                 return false;
             }

--- a/Runtime/GameObjectMatchers/ComponentMatcher.cs
+++ b/Runtime/GameObjectMatchers/ComponentMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/ComponentMatcher.cs
+++ b/Runtime/GameObjectMatchers/ComponentMatcher.cs
@@ -17,6 +17,9 @@ namespace TestHelper.UI.GameObjectMatchers
         private readonly string _name;
         private readonly string _path;
 
+        /// <inheritdoc/>
+        public Type ComponentType => null;
+
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/Runtime/GameObjectMatchers/ComponentMatcher.cs
+++ b/Runtime/GameObjectMatchers/ComponentMatcher.cs
@@ -13,12 +13,11 @@ namespace TestHelper.UI.GameObjectMatchers
     /// </summary>
     public class ComponentMatcher : IGameObjectMatcher
     {
-        private readonly Type _componentType;
         private readonly string _name;
         private readonly string _path;
 
         /// <inheritdoc/>
-        public Type ComponentType => null;
+        public Type ComponentType { get; }
 
         /// <summary>
         /// Constructor.
@@ -29,7 +28,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
         public ComponentMatcher(Type componentType = null, string name = null, string path = null)
         {
-            _componentType = componentType ?? typeof(Component);
+            ComponentType = componentType ?? typeof(Component);
             _name = name;
             _path = path;
         }
@@ -37,7 +36,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public override string ToString()
         {
-            var builder = new StringBuilder($"type={_componentType}");
+            var builder = new StringBuilder($"type={ComponentType}");
             if (_name != null)
             {
                 builder.Append($", name={_name}");
@@ -54,7 +53,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public bool IsMatch(GameObject gameObject)
         {
-            if (!gameObject.TryGetComponent(_componentType, out _))
+            if (!gameObject.TryGetComponent(ComponentType, out _))
             {
                 return false;
             }

--- a/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
+++ b/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
+++ b/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
@@ -13,9 +13,11 @@ namespace TestHelper.UI.GameObjectMatchers
     public interface IGameObjectMatcher
     {
         /// <summary>
-        /// The <c>Component</c> type used by <see cref="GameObjectFinder"/> to collect candidate
+        /// The component type used by <see cref="GameObjectFinder"/> to collect candidate
         /// <see cref="GameObject"/>s before evaluating <see cref="IsMatch"/>.
         /// Matchers without a component criterion return <c>typeof(Transform)</c>.
+        /// A non-<c>Component</c> type (e.g., an interface) is allowed; <see cref="GameObjectFinder"/>
+        /// then collects candidates via <c>typeof(Transform)</c> and <see cref="IsMatch"/> does the filtering.
         /// </summary>
         Type ComponentType { get; }
 

--- a/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
+++ b/Runtime/GameObjectMatchers/IGameObjectMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using UnityEngine;
 
 namespace TestHelper.UI.GameObjectMatchers
@@ -11,6 +12,13 @@ namespace TestHelper.UI.GameObjectMatchers
     /// </summary>
     public interface IGameObjectMatcher
     {
+        /// <summary>
+        /// The <c>Component</c> type used by <see cref="GameObjectFinder"/> to collect candidate
+        /// <see cref="GameObject"/>s before evaluating <see cref="IsMatch"/>.
+        /// Matchers without a component criterion return <c>typeof(Transform)</c>.
+        /// </summary>
+        Type ComponentType { get; }
+
         /// <summary>
         /// Determines if a <see cref="GameObject"/> matches the implemented criteria.
         /// </summary>

--- a/Runtime/GameObjectMatchers/NameMatcher.cs
+++ b/Runtime/GameObjectMatchers/NameMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/NameMatcher.cs
+++ b/Runtime/GameObjectMatchers/NameMatcher.cs
@@ -14,7 +14,7 @@ namespace TestHelper.UI.GameObjectMatchers
         private readonly string _name;
 
         /// <inheritdoc/>
-        public Type ComponentType => null;
+        public Type ComponentType => typeof(Transform);
 
         /// <summary>
         /// Constructor with name.

--- a/Runtime/GameObjectMatchers/NameMatcher.cs
+++ b/Runtime/GameObjectMatchers/NameMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using UnityEngine;
 
 namespace TestHelper.UI.GameObjectMatchers
@@ -11,6 +12,9 @@ namespace TestHelper.UI.GameObjectMatchers
     public class NameMatcher : IGameObjectMatcher
     {
         private readonly string _name;
+
+        /// <inheritdoc/>
+        public Type ComponentType => null;
 
         /// <summary>
         /// Constructor with name.

--- a/Runtime/GameObjectMatchers/NameMatcher.cs
+++ b/Runtime/GameObjectMatchers/NameMatcher.cs
@@ -9,6 +9,9 @@ namespace TestHelper.UI.GameObjectMatchers
     /// <summary>
     /// <see cref="GameObject"/> matcher that matchers by name.
     /// </summary>
+    /// <remarks>
+    /// Using a matcher that lets you specify the component type improves both execution performance and memory usage.
+    /// </remarks>
     public class NameMatcher : IGameObjectMatcher
     {
         private readonly string _name;

--- a/Runtime/GameObjectMatchers/PathMatcher.cs
+++ b/Runtime/GameObjectMatchers/PathMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/PathMatcher.cs
+++ b/Runtime/GameObjectMatchers/PathMatcher.cs
@@ -10,6 +10,9 @@ namespace TestHelper.UI.GameObjectMatchers
     /// <summary>
     /// <see cref="GameObject"/> matcher that matchers by hierarchy path.
     /// </summary>
+    /// <remarks>
+    /// Using a matcher that lets you specify the component type improves both execution performance and memory usage.
+    /// </remarks>
     public class PathMatcher : IGameObjectMatcher
     {
         private readonly string _path;

--- a/Runtime/GameObjectMatchers/PathMatcher.cs
+++ b/Runtime/GameObjectMatchers/PathMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
+using System;
 using TestHelper.UI.Extensions;
 using UnityEngine;
 
@@ -12,6 +13,9 @@ namespace TestHelper.UI.GameObjectMatchers
     public class PathMatcher : IGameObjectMatcher
     {
         private readonly string _path;
+
+        /// <inheritdoc/>
+        public Type ComponentType => null;
 
         /// <summary>
         /// Constructor with hierarchy path.

--- a/Runtime/GameObjectMatchers/PathMatcher.cs
+++ b/Runtime/GameObjectMatchers/PathMatcher.cs
@@ -15,7 +15,7 @@ namespace TestHelper.UI.GameObjectMatchers
         private readonly string _path;
 
         /// <inheritdoc/>
-        public Type ComponentType => null;
+        public Type ComponentType => typeof(Transform);
 
         /// <summary>
         /// Constructor with hierarchy path.

--- a/Runtime/GameObjectMatchers/ToggleMatcher.cs
+++ b/Runtime/GameObjectMatchers/ToggleMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Runtime/GameObjectMatchers/ToggleMatcher.cs
+++ b/Runtime/GameObjectMatchers/ToggleMatcher.cs
@@ -21,13 +21,12 @@ namespace TestHelper.UI.GameObjectMatchers
     /// </remarks>
     public class ToggleMatcher : IGameObjectMatcher
     {
-        private readonly Type _componentType;
         private readonly string _name;
         private readonly string _path;
         private readonly string _text;
 
         /// <inheritdoc/>
-        public Type ComponentType => null;
+        public Type ComponentType { get; }
 
         /// <summary>
         /// Constructor with properties of <c>Toggle</c>.
@@ -39,7 +38,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <seealso href="https://en.wikipedia.org/wiki/Glob_(programming)"/>
         public ToggleMatcher(Type componentType = null, string name = null, string path = null, string text = null)
         {
-            _componentType = componentType ?? typeof(Toggle);
+            ComponentType = componentType ?? typeof(Toggle);
             _name = name;
             _path = path;
             _text = text;
@@ -48,7 +47,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public override string ToString()
         {
-            var builder = new StringBuilder($"type={_componentType}");
+            var builder = new StringBuilder($"type={ComponentType}");
             if (_name != null)
             {
                 builder.Append($", name={_name}");
@@ -70,7 +69,7 @@ namespace TestHelper.UI.GameObjectMatchers
         /// <inheritdoc/>
         public bool IsMatch(GameObject gameObject)
         {
-            if (!gameObject.TryGetComponent(_componentType, out _))
+            if (!gameObject.TryGetComponent(ComponentType, out _))
             {
                 return false;
             }

--- a/Runtime/GameObjectMatchers/ToggleMatcher.cs
+++ b/Runtime/GameObjectMatchers/ToggleMatcher.cs
@@ -26,6 +26,9 @@ namespace TestHelper.UI.GameObjectMatchers
         private readonly string _path;
         private readonly string _text;
 
+        /// <inheritdoc/>
+        public Type ComponentType => null;
+
         /// <summary>
         /// Constructor with properties of <c>Toggle</c>.
         /// </summary>

--- a/Runtime/InteractableComponentsFinder.cs
+++ b/Runtime/InteractableComponentsFinder.cs
@@ -9,7 +9,6 @@ using TestHelper.UI.Strategies;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using Object = UnityEngine.Object;
 
 namespace TestHelper.UI
 {
@@ -140,14 +139,7 @@ namespace TestHelper.UI
 
         private static MonoBehaviour[] FindMonoBehaviours()
         {
-#if UNITY_6000_4_OR_NEWER
-            return Object.FindObjectsByType<MonoBehaviour>(FindObjectsInactive.Exclude);
-#elif UNITY_2022_3_OR_NEWER
-            return Object.FindObjectsByType<MonoBehaviour>(FindObjectsSortMode.None);
-            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
-#else
-            return Object.FindObjectsOfType<MonoBehaviour>();
-#endif
+            return ObjectExtensions.FindObjectsByType<MonoBehaviour>();
         }
     }
 }

--- a/Runtime/Operators/UguiDragAndDropOperator.cs
+++ b/Runtime/Operators/UguiDragAndDropOperator.cs
@@ -15,7 +15,6 @@ using TestHelper.UI.Strategies;
 using TestHelper.UI.Visualizers;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using Object = UnityEngine.Object;
 
 namespace TestHelper.UI.Operators
 {
@@ -166,14 +165,7 @@ namespace TestHelper.UI.Operators
 
         private static DropAnnotation[] FindDropAnnotations()
         {
-#if UNITY_6000_4_OR_NEWER
-            return Object.FindObjectsByType<DropAnnotation>(FindObjectsInactive.Exclude);
-#elif UNITY_2022_3_OR_NEWER
-            return Object.FindObjectsByType<DropAnnotation>(FindObjectsSortMode.None);
-            // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
-#else
-            return Object.FindObjectsOfType<DropAnnotation>();
-#endif
+            return ObjectExtensions.FindObjectsByType<DropAnnotation>();
         }
 
         internal Component LotteryComponent(IReadOnlyList<Component> components)

--- a/Tests/Runtime/GameObjectFinderTest.cs
+++ b/Tests/Runtime/GameObjectFinderTest.cs
@@ -17,6 +17,7 @@ using TestHelper.UI.Strategies;
 using TestHelper.UI.TestDoubles;
 using TestHelper.UI.Visualizers;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using Is = TestHelper.Constraints.Is;
@@ -359,6 +360,19 @@ namespace TestHelper.UI
                 var result = await _sut.FindByNameAsync(target.name);
                 Assert.That(result.GameObject, Is.EqualTo(target));
             }
+
+            [Test]
+            [LoadScene(TestScenePath)]
+            public async Task FindByNameAsync_MultipleScenesLoaded_Found()
+            {
+                var target = GameObject.Find("EventHandler");
+
+                var additiveScene = SceneManager.CreateScene("AdditiveScene");
+                SceneManager.MoveGameObjectToScene(target, additiveScene);
+
+                var result = await _sut.FindByNameAsync(target.name);
+                Assert.That(result.GameObject, Is.EqualTo(target));
+            }
         }
 
         [TestFixture]
@@ -641,6 +655,53 @@ namespace TestHelper.UI
                 Assert.That(indicator, Is.Not.Null);
                 Assert.That(indicator.GetComponent<Image>().sprite.name, Is.EqualTo("hand_slash"));
             }
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        [CreateScene]
+        public async Task FindByMatcherAsync_MultipleComponentsOfSameTypeOnOneGameObject_Found()
+        {
+            var target = new GameObject("Target");
+            target.AddComponent<BoxCollider>();
+            target.AddComponent<BoxCollider>();
+            var sut = new GameObjectFinder(0.1d);
+
+            var matcher = new ComponentMatcher(componentType: typeof(BoxCollider));
+            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+
+            Assert.That(result.GameObject, Is.EqualTo(target));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        [CreateScene]
+        public async Task FindByMatcherAsync_DefaultComponentTypeOnGameObjectWithMultipleComponents_Found()
+        {
+            var target = new GameObject("Target");
+            target.AddComponent<BoxCollider>();
+            target.AddComponent<AudioSource>();
+            var sut = new GameObjectFinder(0.1d);
+
+            var matcher = new ComponentMatcher(name: "Target"); // component type defaults to Component
+            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+
+            Assert.That(result.GameObject, Is.EqualTo(target));
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        [CreateScene]
+        public async Task FindByMatcherAsync_ComponentTypeIsInterface_Found()
+        {
+            var target = new GameObject("Target");
+            target.AddComponent<Button>(); // Button implements IPointerClickHandler
+            var sut = new GameObjectFinder(0.1d);
+
+            var matcher = new ComponentMatcher(componentType: typeof(IPointerClickHandler));
+            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+
+            Assert.That(result.GameObject, Is.EqualTo(target));
         }
 
         [Test]

--- a/Tests/Runtime/GameObjectFinderTest.cs
+++ b/Tests/Runtime/GameObjectFinderTest.cs
@@ -2,7 +2,6 @@
 // This software is released under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
@@ -657,51 +656,54 @@ namespace TestHelper.UI
             }
         }
 
-        [Test]
-        [Category("Acceptance")]
-        [CreateScene]
-        public async Task FindByMatcherAsync_MultipleComponentsOfSameTypeOnOneGameObject_Found()
+        [TestFixture]
+        public class Matcher
         {
-            var target = new GameObject("Target");
-            target.AddComponent<BoxCollider>();
-            target.AddComponent<BoxCollider>();
-            var sut = new GameObjectFinder(0.1d);
+            private readonly GameObjectFinder _sut = new GameObjectFinder(0.1d);
 
-            var matcher = new ComponentMatcher(componentType: typeof(BoxCollider));
-            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+            [Test]
+            [Category("Acceptance")]
+            [CreateScene]
+            public async Task FindByMatcherAsync_MultipleComponentsOfSameTypeOnOneGameObject_Found()
+            {
+                var target = new GameObject("Target");
+                target.AddComponent<BoxCollider>();
+                target.AddComponent<BoxCollider>();
 
-            Assert.That(result.GameObject, Is.EqualTo(target));
-        }
+                var matcher = new ComponentMatcher(componentType: typeof(BoxCollider));
+                var result = await _sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
 
-        [Test]
-        [Category("Acceptance")]
-        [CreateScene]
-        public async Task FindByMatcherAsync_DefaultComponentTypeOnGameObjectWithMultipleComponents_Found()
-        {
-            var target = new GameObject("Target");
-            target.AddComponent<BoxCollider>();
-            target.AddComponent<AudioSource>();
-            var sut = new GameObjectFinder(0.1d);
+                Assert.That(result.GameObject, Is.EqualTo(target));
+            }
 
-            var matcher = new ComponentMatcher(name: "Target"); // component type defaults to Component
-            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+            [Test]
+            [Category("Acceptance")]
+            [CreateScene]
+            public async Task FindByMatcherAsync_DefaultComponentTypeOnGameObjectWithMultipleComponents_Found()
+            {
+                var target = new GameObject("Target");
+                target.AddComponent<BoxCollider>();
+                target.AddComponent<AudioSource>();
 
-            Assert.That(result.GameObject, Is.EqualTo(target));
-        }
+                var matcher = new ComponentMatcher(name: "Target"); // component type defaults to Component
+                var result = await _sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
 
-        [Test]
-        [Category("Acceptance")]
-        [CreateScene]
-        public async Task FindByMatcherAsync_ComponentTypeIsInterface_Found()
-        {
-            var target = new GameObject("Target");
-            target.AddComponent<Button>(); // Button implements IPointerClickHandler
-            var sut = new GameObjectFinder(0.1d);
+                Assert.That(result.GameObject, Is.EqualTo(target));
+            }
 
-            var matcher = new ComponentMatcher(componentType: typeof(IPointerClickHandler));
-            var result = await sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+            [Test]
+            [Category("Acceptance")]
+            [CreateScene]
+            public async Task FindByMatcherAsync_ComponentTypeIsInterface_Found()
+            {
+                var target = new GameObject("Target");
+                target.AddComponent<Button>(); // Button implements IPointerClickHandler
 
-            Assert.That(result.GameObject, Is.EqualTo(target));
+                var matcher = new ComponentMatcher(componentType: typeof(IPointerClickHandler));
+                var result = await _sut.FindByMatcherAsync(matcher, reachable: false, interactable: false);
+
+                Assert.That(result.GameObject, Is.EqualTo(target));
+            }
         }
 
         [Test]

--- a/Tests/Runtime/GameObjectMatchers/ButtonMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ButtonMatcherTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.UI.TestDoubles;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -13,6 +14,21 @@ namespace TestHelper.UI.GameObjectMatchers
     [TestFixture]
     public class ButtonMatcherTest
     {
+        [Test]
+        [Category("Acceptance")]
+        public void ComponentType_WithoutComponentType_ReturnsButton()
+        {
+            var sut = new ButtonMatcher();
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Button)));
+        }
+
+        [Test]
+        public void ComponentType_WithComponentType_ReturnsSpecifiedType()
+        {
+            var sut = new ButtonMatcher(componentType: typeof(FakeComponent));
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(FakeComponent)));
+        }
+
         [Test]
         public void ToString_WithoutArguments_ReturnsOnlyType()
         {

--- a/Tests/Runtime/GameObjectMatchers/ButtonMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ButtonMatcherTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Linq;

--- a/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace TestHelper.UI.GameObjectMatchers
@@ -13,6 +14,21 @@ namespace TestHelper.UI.GameObjectMatchers
     [TestFixture]
     public class ComponentMatcherTest
     {
+        [Test]
+        [Category("Acceptance")]
+        public void ComponentType_WithoutComponentType_ReturnsComponent()
+        {
+            var sut = new ComponentMatcher();
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Component)));
+        }
+
+        [Test]
+        public void ComponentType_WithComponentType_ReturnsSpecifiedType()
+        {
+            var sut = new ComponentMatcher(componentType: typeof(Transform));
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Transform)));
+        }
+
         [Test]
         public void ToString_WithoutArguments_ReturnsOnlyType()
         {
@@ -70,6 +86,16 @@ namespace TestHelper.UI.GameObjectMatchers
             var sut = new ComponentMatcher(path: "/Path/To/Transform");
             var actual = sut.IsMatch(CreateGameObject(path: "/Path/To/Not/Transform"));
             Assert.That(actual, Is.False);
+        }
+
+        [Test]
+        [Category("Acceptance")]
+        [CreateScene]
+        public void IsMatch_ComponentTypeIsInterface_ReturnsTrue()
+        {
+            var sut = new ComponentMatcher(componentType: typeof(IPointerClickHandler));
+            var actual = sut.IsMatch(CreateGameObject(componentType: typeof(Button))); // Button implements IPointerClickHandler
+            Assert.That(actual, Is.True);
         }
 
         [Test]

--- a/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ComponentMatcherTest.cs
@@ -94,7 +94,8 @@ namespace TestHelper.UI.GameObjectMatchers
         public void IsMatch_ComponentTypeIsInterface_ReturnsTrue()
         {
             var sut = new ComponentMatcher(componentType: typeof(IPointerClickHandler));
-            var actual = sut.IsMatch(CreateGameObject(componentType: typeof(Button))); // Button implements IPointerClickHandler
+            var actual =
+                sut.IsMatch(CreateGameObject(componentType: typeof(Button))); // Button implements IPointerClickHandler
             Assert.That(actual, Is.True);
         }
 

--- a/Tests/Runtime/GameObjectMatchers/NameMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/NameMatcherTest.cs
@@ -11,6 +11,14 @@ namespace TestHelper.UI.GameObjectMatchers
     public class NameMatcherTest
     {
         [Test]
+        [Category("Acceptance")]
+        public void ComponentType_ReturnsTransform()
+        {
+            var sut = new NameMatcher("Button");
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Transform)));
+        }
+
+        [Test]
         public void ToString_ReturnsWithName()
         {
             var sut = new NameMatcher("Button");

--- a/Tests/Runtime/GameObjectMatchers/NameMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/NameMatcherTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using NUnit.Framework;

--- a/Tests/Runtime/GameObjectMatchers/PathMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/PathMatcherTest.cs
@@ -12,6 +12,14 @@ namespace TestHelper.UI.GameObjectMatchers
     public class PathMatcherTest
     {
         [Test]
+        [Category("Acceptance")]
+        public void ComponentType_ReturnsTransform()
+        {
+            var sut = new PathMatcher("/Path/To/Button");
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Transform)));
+        }
+
+        [Test]
         public void ToString_ReturnsWithPath()
         {
             var sut = new PathMatcher("/Path/To/Button");

--- a/Tests/Runtime/GameObjectMatchers/PathMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/PathMatcherTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.Linq;

--- a/Tests/Runtime/GameObjectMatchers/ToggleMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ToggleMatcherTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;

--- a/Tests/Runtime/GameObjectMatchers/ToggleMatcherTest.cs
+++ b/Tests/Runtime/GameObjectMatchers/ToggleMatcherTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using TestHelper.Attributes;
+using TestHelper.UI.TestDoubles;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,6 +15,21 @@ namespace TestHelper.UI.GameObjectMatchers
     [TestFixture]
     public class ToggleMatcherTest
     {
+        [Test]
+        [Category("Acceptance")]
+        public void ComponentType_WithoutComponentType_ReturnsToggle()
+        {
+            var sut = new ToggleMatcher();
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(Toggle)));
+        }
+
+        [Test]
+        public void ComponentType_WithComponentType_ReturnsSpecifiedType()
+        {
+            var sut = new ToggleMatcher(componentType: typeof(FakeComponent));
+            Assert.That(sut.ComponentType, Is.EqualTo(typeof(FakeComponent)));
+        }
+
         [Test]
         public void ToString_WithoutArguments_ReturnsOnlyType()
         {


### PR DESCRIPTION
## What

- Add `Type ComponentType { get; }` to `IGameObjectMatcher` so every matcher exposes a component type as a candidate-collection hint (`NameMatcher`/`PathMatcher` return `typeof(Transform)`; the component-based matchers expose their constructor argument)
- Replace `GameObjectFinder`'s recursive hierarchy traversal with `Object.FindObjectsByType(matcher.ComponentType, ...)`, deduped per GameObject. Deletes the DontDestroyOnLoad dummy-object hack and the unreachable scene-scoped search path
- Reuse the raycast captured during reachability filtering instead of raycasting the surviving object a second time
- Reuse `GameObjectFinder`'s per-find candidate buffers (`HashSet<GameObject>`, `List<GameObject>`, `Dictionary<GameObject, RaycastResult>`) as instance fields, `Clear()`-ing them on each call instead of allocating fresh ones every poll

## Why

The recursive iterator over every scene root dominated finder cost on deep hierarchies through nested-iterator overhead and GC allocations.

Performance test results (1000 buttons x nest depth 10, median of 20 iterations, Unity 6000.4 Editor / macOS), comparing this branch's tip against `master`:

### FindByMatcherAsync_ButtonMatcherAmongManyGameObjects

| Metric | Before | After | Change |
|---|---|---|---|
| Time (ms) Median | 5.560 | 0.774 | -86.1% |
| GC.Alloc (bytes) Median | 1,945,600 | 8,192 | -99.6% |

### FindByNameAsync_AmongManyGameObjects

| Metric | Before | After | Change |
|---|---|---|---|
| Time (ms) Median | 5.489 | 3.606 | -34.3% |
| GC.Alloc (bytes) Median | 2,293,760 | 450,560 | -80.4% |

### FindByMatcherAsync_WithPaginatorInScrollView

| Metric | Before | After | Change |
|---|---|---|---|
| Time (ms) Median | 4.137 | 3.881 | -6.2% |
| GC.Alloc (bytes) Median | 241,664 | 8,192 | -96.6% |

## Breaking change

`IGameObjectMatcher` gains a required `ComponentType` member; external implementers must add it (documented in the README extension-point section).

## Behavior notes

- Inactive objects remain excluded; DontDestroyOnLoad and non-active-scene objects remain found (pinned by existing tests, all green: 236 functional tests)
- A GameObject holding multiple matching components matches once (new regression tests)
- Interface component types still work: candidate collection falls back to `typeof(Transform)` and `IsMatch` filters via `TryGetComponent`
- `FindObjectsByType` does not return `HideFlags.DontSave` objects; the old traversal could. Accepted as undefined behavior not pinned by any test
- The reused candidate buffers make a single `GameObjectFinder` instance unsafe for concurrent finds; this was already implicitly true (shared `_reachableStrategy`/`_visualizer` state) and is now called out in a code comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)