### PR TITLE
Upgrade Unity versions used to run tests on CI (Unity 6.6)

### DIFF
--- a/.github/workflows/metacheck.yml
+++ b/.github/workflows/metacheck.yml
@@ -31,14 +31,3 @@ jobs:
           lfs: false
 
       - uses: DeNA/unity-meta-check@a2e35e2c0b652031facd143db6f0a438b49de38a # v4
-
-      - uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,job,pullRequest
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.event.pull_request.head.repo.fork == false # Skip on public fork, because can not read secrets.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   release-drafter:
-    if: github.repository_owner == 'nowsprinting' # Skip on forked repo
+    if: github.event.repository.fork == false # Skip on forked repo
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # After tagged, openupm.com gets the tag and automatically publishes the UPM package.
-
-      - uses: 8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,job,pullRequest
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   check-bump-version:
-    if: github.repository_owner == 'nowsprinting' # Skip on forked repo
+    if: github.event.repository.fork == false # Skip on forked repo
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,9 @@ jobs:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.41f2
           - 2022.3.62f3 # Non-Enterprise LTS
-          - 6000.0.77f1
-          - 6000.3.18f1
-          - &latest_unity_version 6000.5.0f1
+          - 6000.0.82f1
+          - 6000.3.23f1
+          - &latest_unity_version 6000.6.0f1
         testMode:
           - All # run tests in editor
         inputHandler:
@@ -128,7 +128,7 @@ jobs:
         run: echo "secret_key=UNITY_LICENSE_$(echo ${{ matrix.unityVersion }} | cut -c 1-4)" >> "$GITHUB_ENV"
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4
+        uses: game-ci/unity-test-runner@f7d28f891263d875d47ef34370e9e8dd6087e1ef  # v5.0.0-beta.1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`

--- a/Tests/Runtime/Paginators/IPaginatorTest.cs
+++ b/Tests/Runtime/Paginators/IPaginatorTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Koji Hasegawa.
+// Copyright (c) 2023-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System;
@@ -6,6 +6,9 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
+#if UNITY_6000_4_OR_NEWER
+using UnityEngine.Assemblies;
+#endif
 
 namespace TestHelper.UI.Paginators
 {
@@ -15,7 +18,11 @@ namespace TestHelper.UI.Paginators
         private static Type[] GetPaginators()
         {
             var interfaceType = typeof(IPaginator);
+#if UNITY_6000_4_OR_NEWER
+            return CurrentAssemblies.GetLoadedAssemblies()
+#else
             return AppDomain.CurrentDomain.GetAssemblies()
+#endif
                 .SelectMany(assembly =>
                 {
                     try


### PR DESCRIPTION
## Summary

- Add Unity 6000.6.0f1 to the CI test matrix and bump the other Unity 6 entries (6000.0.82f1, 6000.3.23f1); switch to game-ci/unity-test-runner v5.0.0-beta.1
- Use `CurrentAssemblies.GetLoadedAssemblies()` on Unity 6000.4 or newer, since `AppDomain.CurrentDomain.GetAssemblies()` reported UAC0005 on Unity 6.6
- Workflow housekeeping: drop the Slack notification steps from release/metacheck, and gate fork-only jobs on `github.event.repository.fork` instead of a hardcoded owner name
